### PR TITLE
evm: fix sig verification

### DIFF
--- a/app/ante/eth_test.go
+++ b/app/ante/eth_test.go
@@ -23,7 +23,7 @@ func (suite AnteTestSuite) TestEthSigVerificationDecorator() {
 
 	signedTx := evmtypes.NewMsgEthereumTxContract(suite.app.EvmKeeper.ChainID(), 1, big.NewInt(10), 1000, big.NewInt(1), nil, nil)
 	signedTx.From = addr.Hex()
-	err := signedTx.Sign(suite.app.EvmKeeper.ChainID(), tests.NewSigner(privKey))
+	err := signedTx.Sign(suite.ethSigner, tests.NewSigner(privKey))
 	suite.Require().NoError(err)
 
 	testCases := []struct {
@@ -312,7 +312,7 @@ func (suite AnteTestSuite) TestEthIncrementSenderSequenceDecorator() {
 
 	signedTx := evmtypes.NewMsgEthereumTxContract(suite.app.EvmKeeper.ChainID(), 1, big.NewInt(10), 1000, big.NewInt(1), nil, nil)
 	signedTx.From = addr.Hex()
-	err := signedTx.Sign(suite.app.EvmKeeper.ChainID(), tests.NewSigner(privKey))
+	err := signedTx.Sign(suite.ethSigner, tests.NewSigner(privKey))
 	suite.Require().NoError(err)
 
 	testCases := []struct {

--- a/app/ante/utils_test.go
+++ b/app/ante/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/stretchr/testify/suite"
@@ -37,6 +38,7 @@ type AnteTestSuite struct {
 	clientCtx   client.Context
 	txBuilder   client.TxBuilder
 	anteHandler sdk.AnteHandler
+	ethSigner   ethtypes.Signer
 }
 
 func (suite *AnteTestSuite) SetupTest() {
@@ -59,6 +61,7 @@ func (suite *AnteTestSuite) SetupTest() {
 	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
 
 	suite.anteHandler = ante.NewAnteHandler(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.EvmKeeper, encodingConfig.TxConfig.SignModeHandler())
+	suite.ethSigner = ethtypes.LatestSignerForChainID(suite.app.EvmKeeper.ChainID())
 }
 
 func TestAnteTestSuite(t *testing.T) {
@@ -78,7 +81,7 @@ func (suite *AnteTestSuite) CreateTestTx(
 
 	builder.SetExtensionOptions(option)
 
-	err = msg.Sign(suite.app.EvmKeeper.ChainID(), tests.NewSigner(priv))
+	err = msg.Sign(suite.ethSigner, tests.NewSigner(priv))
 	suite.Require().NoError(err)
 
 	err = builder.SetMsgs(msg)

--- a/ethereum/rpc/eth_api.go
+++ b/ethereum/rpc/eth_api.go
@@ -380,8 +380,12 @@ func (e *PublicEthAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, e
 		return common.Hash{}, err
 	}
 
+	// creates a new EIP2929 signer
+	// TODO: support legacy txs
+	signer := ethtypes.LatestSignerForChainID(args.ChainID.ToInt())
+
 	// Sign transaction
-	if err := tx.Sign(e.chainIDEpoch, e.clientCtx.Keyring); err != nil {
+	if err := tx.Sign(signer, e.clientCtx.Keyring); err != nil {
 		e.logger.Debugln("failed to sign tx", "error", err)
 		return common.Hash{}, err
 	}

--- a/tests/importer/importer_test.go
+++ b/tests/importer/importer_test.go
@@ -185,15 +185,19 @@ func TestImportBlocks(t *testing.T) {
 	bankStoreKey := sdk.NewKVStoreKey(banktypes.StoreKey)
 	evmStoreKey := sdk.NewKVStoreKey(evmtypes.StoreKey)
 	paramsStoreKey := sdk.NewKVStoreKey(paramtypes.StoreKey)
+	evmTransientStoreKey := sdk.NewTransientStoreKey(evmtypes.TransientKey)
 	paramsTransientStoreKey := sdk.NewTransientStoreKey(paramtypes.TStoreKey)
 
 	// mount stores
 	keys := []*sdk.KVStoreKey{authStoreKey, bankStoreKey, evmStoreKey, paramsStoreKey}
+	tkeys := []*sdk.TransientStoreKey{paramsTransientStoreKey, evmTransientStoreKey}
 	for _, key := range keys {
 		cms.MountStoreWithDB(key, sdk.StoreTypeIAVL, nil)
 	}
 
-	cms.MountStoreWithDB(paramsTransientStoreKey, sdk.StoreTypeTransient, nil)
+	for _, tkey := range tkeys {
+		cms.MountStoreWithDB(tkey, sdk.StoreTypeTransient, nil)
+	}
 
 	paramsKeeper := paramkeeper.NewKeeper(cdc, amino, paramsStoreKey, paramsTransientStoreKey)
 
@@ -205,7 +209,7 @@ func TestImportBlocks(t *testing.T) {
 	// create keepers
 	ak := authkeeper.NewAccountKeeper(cdc, authStoreKey, authSubspace, types.ProtoAccount, nil)
 	bk := bankkeeper.NewBaseKeeper(cdc, bankStoreKey, ak, bankSubspace, nil)
-	evmKeeper := evmkeeper.NewKeeper(cdc, evmStoreKey, evmSubspace, ak, bk)
+	evmKeeper := evmkeeper.NewKeeper(cdc, evmStoreKey, evmTransientStoreKey, evmSubspace, ak, bk)
 
 	cms.SetPruning(sdkstore.PruneNothing)
 

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -111,7 +111,6 @@ func (suite *MsgsTestSuite) TestMsgEthereumTx_RLPSignBytes() {
 func (suite *MsgsTestSuite) TestMsgEthereumTx_Sign() {
 	msg := NewMsgEthereumTx(suite.chainID, 0, &suite.to, nil, 100000, nil, []byte("test"), nil)
 
-	// TODO: support other legacy signers
 	testCases := []struct {
 		msg        string
 		ethSigner  ethtypes.Signer
@@ -119,10 +118,29 @@ func (suite *MsgsTestSuite) TestMsgEthereumTx_Sign() {
 		expectPass bool
 	}{
 		{
-			"pass",
+			"pass - EIP2930 signer",
 			ethtypes.NewEIP2930Signer(suite.chainID),
 			func() { msg.From = suite.from.Hex() },
 			true,
+		},
+		// TODO: support legacy txs
+		{
+			"not supported - EIP155 signer",
+			ethtypes.NewEIP155Signer(suite.chainID),
+			func() { msg.From = suite.from.Hex() },
+			false,
+		},
+		{
+			"not supported - Homestead signer",
+			ethtypes.HomesteadSigner{},
+			func() { msg.From = suite.from.Hex() },
+			false,
+		},
+		{
+			"not supported - Frontier signer",
+			ethtypes.FrontierSigner{},
+			func() { msg.From = suite.from.Hex() },
+			false,
 		},
 		{
 			"no from address ",

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -111,23 +111,28 @@ func (suite *MsgsTestSuite) TestMsgEthereumTx_RLPSignBytes() {
 func (suite *MsgsTestSuite) TestMsgEthereumTx_Sign() {
 	msg := NewMsgEthereumTx(suite.chainID, 0, &suite.to, nil, 100000, nil, []byte("test"), nil)
 
+	// TODO: support other legacy signers
 	testCases := []struct {
 		msg        string
+		ethSigner  ethtypes.Signer
 		malleate   func()
 		expectPass bool
 	}{
 		{
 			"pass",
+			ethtypes.NewEIP2930Signer(suite.chainID),
 			func() { msg.From = suite.from.Hex() },
 			true,
 		},
 		{
 			"no from address ",
+			ethtypes.NewEIP2930Signer(suite.chainID),
 			func() { msg.From = "" },
 			false,
 		},
 		{
 			"from address ≠ signer address",
+			ethtypes.NewEIP2930Signer(suite.chainID),
 			func() { msg.From = suite.to.Hex() },
 			false,
 		},
@@ -135,7 +140,8 @@ func (suite *MsgsTestSuite) TestMsgEthereumTx_Sign() {
 
 	for i, tc := range testCases {
 		tc.malleate()
-		err := msg.Sign(suite.chainID, suite.signer)
+
+		err := msg.Sign(tc.ethSigner, suite.signer)
 		if tc.expectPass {
 			suite.Require().NoError(err, "valid test %d failed: %s", i, tc.msg)
 


### PR DESCRIPTION
fixes signature verification by leveraging the Signer interface from geth. Currently only supports EIP2929 signer (no legacy txs)