### PR TITLE
Fix blockbloom in header error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
     response now contains the ethereum-formatted `Hash` in hex format.
 * (eth) [\#845](https://github.com/cosmos/ethermint/pull/845) The `eth` namespace must be included in the list of API's as default to run the rpc server without error.
 * (evm) [#202](https://github.com/tharsis/ethermint/pull/202) Web3 api `SendTransaction`/`SendRawTransaction` returns ethereum compatible transaction hash, and query api `GetTransaction*` also accept that.
-* (rpc) [#258](https://github.com/tharsis/ethermint/pull/258) Return empty bloomfilter instead of throwing error when it cannot be found (nil or empty).
+* (rpc) [tharsis#258](https://github.com/tharsis/ethermint/pull/258) Return empty `BloomFilter` instead of throwing an error when it cannot be found (`nil` or empty).
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
     response now contains the ethereum-formatted `Hash` in hex format.
 * (eth) [\#845](https://github.com/cosmos/ethermint/pull/845) The `eth` namespace must be included in the list of API's as default to run the rpc server without error.
 * (evm) [#202](https://github.com/tharsis/ethermint/pull/202) Web3 api `SendTransaction`/`SendRawTransaction` returns ethereum compatible transaction hash, and query api `GetTransaction*` also accept that.
+* (rpc) [#258](https://github.com/tharsis/ethermint/pull/258) Return empty bloomfilter instead of throwing error when it cannot be found (nil or empty).
 
 ### Improvements
 

--- a/ethereum/rpc/backend/backend.go
+++ b/ethereum/rpc/backend/backend.go
@@ -248,7 +248,7 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 
 	req := &evmtypes.QueryBlockBloomRequest{}
 
-	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
+	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height+1), req)
 	if err != nil {
 		e.logger.Debug("HeaderByNumber BlockBloom failed", "height", resBlock.Block.Height)
 		return nil, err

--- a/ethereum/rpc/backend/backend.go
+++ b/ethereum/rpc/backend/backend.go
@@ -248,14 +248,14 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 
 	req := &evmtypes.QueryBlockBloomRequest{}
 
-	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height+1), req)
+	blockBloomResp, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
 	if err != nil {
 		e.logger.Debug("HeaderByNumber BlockBloom failed", "height", resBlock.Block.Height)
-		return nil, err
+		blockBloomResp = &evmtypes.QueryBlockBloomResponse{Bloom: ethtypes.Bloom{}.Bytes()}
 	}
 
 	ethHeader := types.EthHeaderFromTendermint(resBlock.Block.Header)
-	ethHeader.Bloom = ethtypes.BytesToBloom(res.Bloom)
+	ethHeader.Bloom = ethtypes.BytesToBloom(blockBloomResp.Bloom)
 	return ethHeader, nil
 }
 

--- a/ethereum/rpc/backend/backend.go
+++ b/ethereum/rpc/backend/backend.go
@@ -269,14 +269,14 @@ func (e *EVMBackend) HeaderByHash(blockHash common.Hash) (*ethtypes.Header, erro
 
 	req := &evmtypes.QueryBlockBloomRequest{}
 
-	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
+	blockBloomResp, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
 	if err != nil {
 		e.logger.Debug("HeaderByHash BlockBloom failed", "height", resBlock.Block.Height)
-		return nil, err
+		blockBloomResp = &evmtypes.QueryBlockBloomResponse{Bloom: ethtypes.Bloom{}.Bytes()}
 	}
 
 	ethHeader := types.EthHeaderFromTendermint(resBlock.Block.Header)
-	ethHeader.Bloom = ethtypes.BytesToBloom(res.Bloom)
+	ethHeader.Bloom = ethtypes.BytesToBloom(blockBloomResp.Bloom)
 	return ethHeader, nil
 }
 

--- a/ethereum/rpc/types/utils.go
+++ b/ethereum/rpc/types/utils.go
@@ -47,12 +47,12 @@ func EthBlockFromTendermint(clientCtx client.Context, queryClient *QueryClient, 
 
 	req := &evmtypes.QueryBlockBloomRequest{}
 
-	res, err := queryClient.BlockBloom(ContextWithHeight(block.Height), req)
+	blockBloomResp, err := queryClient.BlockBloom(ContextWithHeight(block.Height), req)
 	if err != nil {
-		return nil, err
+		blockBloomResp = &evmtypes.QueryBlockBloomResponse{Bloom: ethtypes.Bloom{}.Bytes()}
 	}
 
-	bloom := ethtypes.BytesToBloom(res.Bloom)
+	bloom := ethtypes.BytesToBloom(blockBloomResp.Bloom)
 
 	return FormatBlock(block.Header, block.Size(), gasLimit, gasUsed, transactions, bloom), nil
 }

--- a/ethereum/rpc/types/utils.go
+++ b/ethereum/rpc/types/utils.go
@@ -33,30 +33,6 @@ func RawTxToEthTx(clientCtx client.Context, txBz tmtypes.Tx) (*evmtypes.MsgEther
 	return ethTx, nil
 }
 
-// EthBlockFromTendermint returns a JSON-RPC compatible Ethereum blockfrom a given Tendermint block.
-func EthBlockFromTendermint(clientCtx client.Context, queryClient *QueryClient, block *tmtypes.Block) (map[string]interface{}, error) {
-	gasLimit, err := BlockMaxGasFromConsensusParams(context.Background(), clientCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	transactions, gasUsed, err := EthTransactionsFromTendermint(clientCtx, block.Txs)
-	if err != nil {
-		return nil, err
-	}
-
-	req := &evmtypes.QueryBlockBloomRequest{}
-
-	blockBloomResp, err := queryClient.BlockBloom(ContextWithHeight(block.Height), req)
-	if err != nil {
-		blockBloomResp = &evmtypes.QueryBlockBloomResponse{Bloom: ethtypes.Bloom{}.Bytes()}
-	}
-
-	bloom := ethtypes.BytesToBloom(blockBloomResp.Bloom)
-
-	return FormatBlock(block.Header, block.Size(), gasLimit, gasUsed, transactions, bloom), nil
-}
-
 // NewTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
 func NewTransaction(tx *ethtypes.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) *RPCTransaction {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -138,23 +138,25 @@ func (k *Keeper) ApplyTransaction(tx *ethtypes.Transaction) (*types.MsgEthereumT
 
 	txHash := tx.Hash()
 	res.Hash = txHash.Hex()
-
-	// Set the bloom filter and commit only if transaction is NOT reverted
 	logs := k.GetTxLogs(txHash)
+
 	// Commit and switch to original context
 	if !res.Reverted {
 		commit()
 	}
 	k.ctx = originalCtx
 
-	// refund gas prior to handling the vm error in order to set the updated gas meter
+	// Logs needs to be ignored when tx is reverted
+	// Set the log and bloom filter only when the tx is NOT REVERTED
 	if !res.Reverted {
 		res.Logs = types.NewLogsFromEth(logs)
-		// update block bloom filter in the original context
+		// Update block bloom filter in the original context because blockbloom is set in EndBlock
 		bloom := k.GetBlockBloomTransient()
 		bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.LogsBloom(logs)))
 		k.SetBlockBloomTransient(bloom)
 	}
+
+	// refund gas prior to handling the vm error in order to set the updated gas meter
 	leftoverGas := msg.Gas() - res.GasUsed
 	leftoverGas, err = k.RefundGas(msg, leftoverGas)
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #248

## Description

When blockbloom is nil and empty it is currently returning an error. We should return an empty bloom instead to avoid breaking other functionnalities.

Note that I have notice a weird behavior with the context (which return a blockboom at currentheight-1 when context is set at current height but it cannot be found is context is set at current height -1

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
