### PR TITLE
rpc: fix inconsistent logging levels

### DIFF
--- a/ethereum/rpc/apis.go
+++ b/ethereum/rpc/apis.go
@@ -4,6 +4,8 @@ package rpc
 
 import (
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/server"
+
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/tharsis/ethermint/ethereum/rpc/backend"
 	"github.com/tharsis/ethermint/ethereum/rpc/namespaces/eth"
@@ -29,10 +31,10 @@ const (
 )
 
 // GetRPCAPIs returns the list of all APIs
-func GetRPCAPIs(clientCtx client.Context, tmWSClient *rpcclient.WSClient) []rpc.API {
+func GetRPCAPIs(ctx *server.Context, clientCtx client.Context, tmWSClient *rpcclient.WSClient) []rpc.API {
 	nonceLock := new(types.AddrLocker)
-	backend := backend.NewEVMBackend(clientCtx)
-	ethAPI := eth.NewPublicAPI(clientCtx, backend, nonceLock)
+	backend := backend.NewEVMBackend(ctx.Logger, clientCtx)
+	ethAPI := eth.NewPublicAPI(ctx.Logger, clientCtx, backend, nonceLock)
 
 	return []rpc.API{
 		{
@@ -50,7 +52,7 @@ func GetRPCAPIs(clientCtx client.Context, tmWSClient *rpcclient.WSClient) []rpc.
 		{
 			Namespace: EthNamespace,
 			Version:   apiVersion,
-			Service:   filters.NewPublicAPI(tmWSClient, backend),
+			Service:   filters.NewPublicAPI(ctx.Logger, tmWSClient, backend),
 			Public:    true,
 		},
 		{
@@ -62,13 +64,13 @@ func GetRPCAPIs(clientCtx client.Context, tmWSClient *rpcclient.WSClient) []rpc.
 		{
 			Namespace: PersonalNamespace,
 			Version:   apiVersion,
-			Service:   personal.NewAPI(ethAPI),
+			Service:   personal.NewAPI(ctx.Logger, ethAPI),
 			Public:    true,
 		},
 		{
 			Namespace: TxPoolNamespace,
 			Version:   apiVersion,
-			Service:   txpool.NewPublicAPI(),
+			Service:   txpool.NewPublicAPI(ctx.Logger),
 			Public:    true,
 		},
 	}

--- a/ethereum/rpc/backend/backend.go
+++ b/ethereum/rpc/backend/backend.go
@@ -239,8 +239,7 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 		height = 1
 	default:
 		if blockNum < 0 {
-			err := errors.Errorf("incorrect block height: %d", height)
-			return nil, err
+			return nil, errors.Errorf("incorrect block height: %d", height)
 		}
 	}
 
@@ -254,7 +253,7 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 
 	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
 	if err != nil {
-		e.logger.Debug("HeaderByNumber BlockBloom fail", "height", resBlock.Block.Height)
+		e.logger.Debug("HeaderByNumber BlockBloom failed", "height", resBlock.Block.Height)
 		return nil, err
 	}
 
@@ -294,7 +293,7 @@ func (e *EVMBackend) GetTransactionLogs(txHash common.Hash) ([]*ethtypes.Log, er
 
 	res, err := e.queryClient.TxLogs(e.ctx, req)
 	if err != nil {
-		e.logger.Debug("TxLogs fail")
+		e.logger.Debug("TxLogs failed", "tx-hash", req.Hash)
 		return nil, err
 	}
 
@@ -330,7 +329,7 @@ func (e *EVMBackend) GetLogs(blockHash common.Hash) ([][]*ethtypes.Log, error) {
 
 	res, err := e.queryClient.BlockLogs(e.ctx, req)
 	if err != nil {
-		e.logger.Debug("BlockLogs failed", "hash", blockHash.Hex())
+		e.logger.Debug("BlockLogs failed", "hash", req.Hash)
 		return nil, err
 	}
 

--- a/ethereum/rpc/backend/backend.go
+++ b/ethereum/rpc/backend/backend.go
@@ -9,8 +9,8 @@ import (
 	"github.com/tharsis/ethermint/ethereum/rpc/types"
 
 	"github.com/pkg/errors"
+	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
-	log "github.com/xlab/suplog"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -58,7 +58,7 @@ type EVMBackend struct {
 }
 
 // NewEVMBackend creates a new EVMBackend instance
-func NewEVMBackend(clientCtx client.Context) *EVMBackend {
+func NewEVMBackend(logger log.Logger, clientCtx client.Context) *EVMBackend {
 	chainID, err := ethermint.ParseChainID(clientCtx.ChainID)
 	if err != nil {
 		panic(err)
@@ -67,7 +67,7 @@ func NewEVMBackend(clientCtx client.Context) *EVMBackend {
 		ctx:         context.Background(),
 		clientCtx:   clientCtx,
 		queryClient: types.NewQueryClient(clientCtx),
-		logger:      log.WithField("module", "evm-backend"),
+		logger:      logger.With("module", "evm-backend"),
 		chainID:     chainID,
 	}
 }
@@ -110,21 +110,21 @@ func (e *EVMBackend) GetBlockByNumber(blockNum types.BlockNumber, fullTx bool) (
 
 	resBlock, err := e.clientCtx.Client.Block(e.ctx, &height)
 	if err != nil {
-		// e.logger.Debugf("GetBlockByNumber safely bumping down from %d to latest", height)
+		// e.logger.Debug("GetBlockByNumber safely bumping down from %d to latest", height)
 		if resBlock, err = e.clientCtx.Client.Block(e.ctx, nil); err != nil {
-			e.logger.WithError(err).Debugln("GetBlockByNumber failed to get latest block")
+			e.logger.Debug("GetBlockByNumber failed to get latest block", "error", err.Error())
 			return nil, nil
 		}
 	}
 
 	if resBlock.Block == nil {
-		e.logger.Debugln("GetBlockByNumber block not found", "height", height)
+		e.logger.Debug("GetBlockByNumber block not found", "height", height)
 		return nil, nil
 	}
 
 	res, err := e.EthBlockFromTendermint(e.clientCtx, e.queryClient, resBlock.Block, fullTx)
 	if err != nil {
-		e.logger.WithError(err).Debugf("EthBlockFromTendermint failed with block %s", resBlock.Block.String())
+		e.logger.Debug("EthBlockFromTendermint failed", "height", height, "error", err.Error())
 	}
 
 	return res, err
@@ -134,12 +134,12 @@ func (e *EVMBackend) GetBlockByNumber(blockNum types.BlockNumber, fullTx bool) (
 func (e *EVMBackend) GetBlockByHash(hash common.Hash, fullTx bool) (map[string]interface{}, error) {
 	resBlock, err := e.clientCtx.Client.BlockByHash(e.ctx, hash.Bytes())
 	if err != nil {
-		e.logger.WithError(err).Debugln("BlockByHash block not found", "hash", hash.Hex())
+		e.logger.Debug("BlockByHash block not found", "hash", hash.Hex(), "error", err.Error())
 		return nil, err
 	}
 
 	if resBlock.Block == nil {
-		e.logger.Debugln("BlockByHash block not found", "hash", hash.Hex())
+		e.logger.Debug("BlockByHash block not found", "hash", hash.Hex())
 		return nil, nil
 	}
 
@@ -161,7 +161,7 @@ func (e *EVMBackend) EthBlockFromTendermint(
 	for i, txBz := range block.Txs {
 		tx, err := e.clientCtx.TxConfig.TxDecoder()(txBz)
 		if err != nil {
-			e.logger.WithError(err).Warningln("failed to decode transaction in block at height ", block.Height)
+			e.logger.Debug("failed to decode transaction in block", "height", block.Height, "error", err.Error())
 			continue
 		}
 
@@ -183,13 +183,13 @@ func (e *EVMBackend) EthBlockFromTendermint(
 			// get full transaction from message data
 			from, err := ethMsg.GetSender(e.chainID)
 			if err != nil {
-				e.logger.WithError(err).Warningln("failed to get sender from already included transaction ", hash)
+				e.logger.Debug("failed to get sender from already included transaction", "hash", hash.Hex(), "error", err.Error())
 				from = common.HexToAddress(ethMsg.From)
 			}
 
 			txData, err := evmtypes.UnpackTxData(ethMsg.Data)
 			if err != nil {
-				e.logger.WithError(err).Debugln("decoding failed")
+				e.logger.Debug("decoding failed", "error", err.Error())
 				return nil, fmt.Errorf("failed to unpack tx data: %w", err)
 			}
 
@@ -202,7 +202,7 @@ func (e *EVMBackend) EthBlockFromTendermint(
 				uint64(i),
 			)
 			if err != nil {
-				e.logger.WithError(err).Debugln("NewTransactionFromData for receipt failed", "hash", hash.Hex)
+				e.logger.Debug("NewTransactionFromData for receipt failed", "hash", hash.Hex(), "error", err.Error())
 				continue
 			}
 			ethRPCTxs = append(ethRPCTxs, ethTx)
@@ -211,15 +211,13 @@ func (e *EVMBackend) EthBlockFromTendermint(
 
 	blockBloomResp, err := queryClient.BlockBloom(types.ContextWithHeight(block.Height), &evmtypes.QueryBlockBloomRequest{})
 	if err != nil {
-		e.logger.WithError(err).Debugln("failed to query BlockBloom", "height", block.Height)
+		e.logger.Debug("failed to query BlockBloom", "height", block.Height, "error", err.Error())
 
 		blockBloomResp = &evmtypes.QueryBlockBloomResponse{Bloom: ethtypes.Bloom{}.Bytes()}
 	}
 
 	bloom := ethtypes.BytesToBloom(blockBloomResp.Bloom)
 	formattedBlock := types.FormatBlock(block.Header, block.Size(), ethermint.DefaultRPCGasLimit, new(big.Int).SetUint64(gasUsed), ethRPCTxs, bloom)
-
-	e.logger.Infoln(formattedBlock)
 	return formattedBlock, nil
 }
 
@@ -248,7 +246,7 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 
 	resBlock, err := e.clientCtx.Client.Block(e.ctx, &height)
 	if err != nil {
-		e.logger.Warningf("HeaderByNumber failed")
+		e.logger.Debug("HeaderByNumber failed")
 		return nil, err
 	}
 
@@ -256,7 +254,7 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 
 	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
 	if err != nil {
-		e.logger.Warningf("HeaderByNumber BlockBloom fail %d", resBlock.Block.Height)
+		e.logger.Debug("HeaderByNumber BlockBloom fail", "height", resBlock.Block.Height)
 		return nil, err
 	}
 
@@ -269,7 +267,7 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 func (e *EVMBackend) HeaderByHash(blockHash common.Hash) (*ethtypes.Header, error) {
 	resBlock, err := e.clientCtx.Client.BlockByHash(e.ctx, blockHash.Bytes())
 	if err != nil {
-		e.logger.Warningf("HeaderByHash fail")
+		e.logger.Debug("HeaderByHash failed", "hash", blockHash.Hex())
 		return nil, err
 	}
 
@@ -277,7 +275,7 @@ func (e *EVMBackend) HeaderByHash(blockHash common.Hash) (*ethtypes.Header, erro
 
 	res, err := e.queryClient.BlockBloom(types.ContextWithHeight(resBlock.Block.Height), req)
 	if err != nil {
-		e.logger.Warningf("HeaderByHash BlockBloom fail %d", resBlock.Block.Height)
+		e.logger.Debug("HeaderByHash BlockBloom failed", "height", resBlock.Block.Height)
 		return nil, err
 	}
 
@@ -296,7 +294,7 @@ func (e *EVMBackend) GetTransactionLogs(txHash common.Hash) ([]*ethtypes.Log, er
 
 	res, err := e.queryClient.TxLogs(e.ctx, req)
 	if err != nil {
-		e.logger.Warningf("TxLogs fail")
+		e.logger.Debug("TxLogs fail")
 		return nil, err
 	}
 
@@ -332,7 +330,7 @@ func (e *EVMBackend) GetLogs(blockHash common.Hash) ([][]*ethtypes.Log, error) {
 
 	res, err := e.queryClient.BlockLogs(e.ctx, req)
 	if err != nil {
-		e.logger.Warningf("BlockLogs fail")
+		e.logger.Debug("BlockLogs failed", "hash", blockHash.Hex())
 		return nil, err
 	}
 
@@ -364,8 +362,7 @@ func (e *EVMBackend) GetLogsByNumber(blockNum types.BlockNumber) ([][]*ethtypes.
 		height = 1
 	default:
 		if blockNum < 0 {
-			err := errors.Errorf("incorrect block height: %d", height)
-			return nil, err
+			return nil, errors.Errorf("incorrect block height: %d", height)
 		}
 	}
 
@@ -375,7 +372,7 @@ func (e *EVMBackend) GetLogsByNumber(blockNum types.BlockNumber) ([][]*ethtypes.
 			return [][]*ethtypes.Log{}, nil
 		}
 
-		e.logger.Warningf("failed to query block at %d", height)
+		e.logger.Debug("failed to query block", "height", height)
 		return nil, err
 	}
 

--- a/ethereum/rpc/namespaces/eth/api.go
+++ b/ethereum/rpc/namespaces/eth/api.go
@@ -198,7 +198,7 @@ func (e *PublicAPI) Accounts() ([]common.Address, error) {
 
 // BlockNumber returns the current block number.
 func (e *PublicAPI) BlockNumber() (hexutil.Uint64, error) {
-	// e.logger.Debug("eth_blockNumber")
+	e.logger.Debug("eth_blockNumber")
 	return e.backend.BlockNumber()
 }
 
@@ -338,7 +338,7 @@ func (e *PublicAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil.By
 	// Sign the requested hash with the wallet
 	signature, _, err := e.clientCtx.Keyring.SignByAddress(from, data)
 	if err != nil {
-		e.logger.Error("keyring.SignByAddress failed")
+		e.logger.Error("keyring.SignByAddress failed", "address", address.Hex())
 		return nil, err
 	}
 
@@ -374,7 +374,7 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 
 	// Sign transaction
 	if err := msg.Sign(signer, e.clientCtx.Keyring); err != nil {
-		e.logger.Debug("failed to sign tx", "error", err)
+		e.logger.Debug("failed to sign tx", "error", err.Error())
 		return common.Hash{}, err
 	}
 
@@ -441,7 +441,7 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 
 // SendRawTransaction send a raw Ethereum transaction.
 func (e *PublicAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error) {
-	e.logger.Debug("eth_sendRawTransaction", "data_len", len(data))
+	e.logger.Debug("eth_sendRawTransaction", "length", len(data))
 
 	// RLP decode raw transaction bytes
 	tx, err := e.clientCtx.TxConfig.TxDecoder()(data)
@@ -550,9 +550,7 @@ func (e *PublicAPI) doCall(
 	return res, nil
 }
 
-//EstimateGas returns an estimate of gas usage for the given smart contract call.
-// It adds 1,000 gas to the returned value instead of using the gas adjustment
-// param from the SDK.
+// EstimateGas returns an estimate of gas usage for the given smart contract call.
 func (e *PublicAPI) EstimateGas(args evmtypes.CallArgs) (hexutil.Uint64, error) {
 	e.logger.Debug("eth_estimateGas")
 
@@ -1089,7 +1087,7 @@ func (e *PublicAPI) getAccountNonce(accAddr common.Address, pending bool, height
 	// to manually add them.
 	pendingTxs, err := e.backend.PendingTransactions()
 	if err != nil {
-		logger.Error("fails to fetch pending transactions", "error", err.Error())
+		logger.Error("failed to fetch pending transactions", "error", err.Error())
 		return nonce, nil
 	}
 

--- a/ethereum/rpc/namespaces/eth/api.go
+++ b/ethereum/rpc/namespaces/eth/api.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	log "github.com/xlab/suplog"
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -48,6 +48,7 @@ type PublicAPI struct {
 
 // NewPublicAPI creates an instance of the public ETH Web3 API.
 func NewPublicAPI(
+	logger log.Logger,
 	clientCtx client.Context,
 	backend backend.Backend,
 	nonceLock *rpctypes.AddrLocker,
@@ -80,7 +81,7 @@ func NewPublicAPI(
 		clientCtx:    clientCtx,
 		queryClient:  rpctypes.NewQueryClient(clientCtx),
 		chainIDEpoch: epoch,
-		logger:       log.WithField("module", "json-rpc"),
+		logger:       logger.With("client", "json-rpc"),
 		backend:      backend,
 		nonceLock:    nonceLock,
 	}
@@ -95,20 +96,20 @@ func (e *PublicAPI) ClientCtx() client.Context {
 
 // ProtocolVersion returns the supported Ethereum protocol version.
 func (e *PublicAPI) ProtocolVersion() hexutil.Uint {
-	e.logger.Debugln("eth_protocolVersion")
+	e.logger.Debug("eth_protocolVersion")
 	return hexutil.Uint(ethermint.ProtocolVersion)
 }
 
 // ChainId returns the chain's identifier in hex format
 func (e *PublicAPI) ChainId() (hexutil.Uint, error) { // nolint
-	e.logger.Debugln("eth_chainId")
+	e.logger.Debug("eth_chainId")
 	return hexutil.Uint(uint(e.chainIDEpoch.Uint64())), nil
 }
 
 // Syncing returns whether or not the current node is syncing with other peers. Returns false if not, or a struct
 // outlining the state of the sync if it is.
 func (e *PublicAPI) Syncing() (interface{}, error) {
-	e.logger.Debugln("eth_syncing")
+	e.logger.Debug("eth_syncing")
 
 	status, err := e.clientCtx.Client.Status(e.ctx)
 	if err != nil {
@@ -130,7 +131,7 @@ func (e *PublicAPI) Syncing() (interface{}, error) {
 
 // Coinbase is the address that staking rewards will be send to (alias for Etherbase).
 func (e *PublicAPI) Coinbase() (string, error) {
-	e.logger.Debugln("eth_coinbase")
+	e.logger.Debug("eth_coinbase")
 
 	node, err := e.clientCtx.GetNode()
 	if err != nil {
@@ -158,19 +159,19 @@ func (e *PublicAPI) Coinbase() (string, error) {
 
 // Mining returns whether or not this node is currently mining. Always false.
 func (e *PublicAPI) Mining() bool {
-	e.logger.Debugln("eth_mining")
+	e.logger.Debug("eth_mining")
 	return false
 }
 
 // Hashrate returns the current node's hashrate. Always 0.
 func (e *PublicAPI) Hashrate() hexutil.Uint64 {
-	e.logger.Debugln("eth_hashrate")
+	e.logger.Debug("eth_hashrate")
 	return 0
 }
 
 // GasPrice returns the current gas price based on Ethermint's gas price oracle.
 func (e *PublicAPI) GasPrice() *hexutil.Big {
-	e.logger.Debugln("eth_gasPrice")
+	e.logger.Debug("eth_gasPrice")
 	// TODO: use minimum value defined in config instead of default or implement oracle
 	out := big.NewInt(ethermint.DefaultGasPrice)
 	return (*hexutil.Big)(out)
@@ -178,7 +179,7 @@ func (e *PublicAPI) GasPrice() *hexutil.Big {
 
 // Accounts returns the list of accounts available to this node.
 func (e *PublicAPI) Accounts() ([]common.Address, error) {
-	e.logger.Debugln("eth_accounts")
+	e.logger.Debug("eth_accounts")
 
 	addresses := make([]common.Address, 0) // return [] instead of nil if empty
 
@@ -197,13 +198,13 @@ func (e *PublicAPI) Accounts() ([]common.Address, error) {
 
 // BlockNumber returns the current block number.
 func (e *PublicAPI) BlockNumber() (hexutil.Uint64, error) {
-	// e.logger.Debugln("eth_blockNumber")
+	// e.logger.Debug("eth_blockNumber")
 	return e.backend.BlockNumber()
 }
 
 // GetBalance returns the provided account's balance up to the provided block number.
 func (e *PublicAPI) GetBalance(address common.Address, blockNum rpctypes.BlockNumber) (*hexutil.Big, error) { // nolint: interfacer
-	e.logger.Debugln("eth_getBalance", "address", address.String(), "block number", blockNum)
+	e.logger.Debug("eth_getBalance", "address", address.String(), "block number", blockNum)
 
 	req := &evmtypes.QueryBalanceRequest{
 		Address: address.String(),
@@ -224,7 +225,7 @@ func (e *PublicAPI) GetBalance(address common.Address, blockNum rpctypes.BlockNu
 
 // GetStorageAt returns the contract storage at the given address, block number, and key.
 func (e *PublicAPI) GetStorageAt(address common.Address, key string, blockNum rpctypes.BlockNumber) (hexutil.Bytes, error) { // nolint: interfacer
-	e.logger.Debugln("eth_getStorageAt", "address", address.Hex(), "key", key, "block number", blockNum)
+	e.logger.Debug("eth_getStorageAt", "address", address.Hex(), "key", key, "block number", blockNum)
 
 	req := &evmtypes.QueryStorageRequest{
 		Address: address.String(),
@@ -242,7 +243,7 @@ func (e *PublicAPI) GetStorageAt(address common.Address, key string, blockNum rp
 
 // GetTransactionCount returns the number of transactions at the given address up to the given block number.
 func (e *PublicAPI) GetTransactionCount(address common.Address, blockNum rpctypes.BlockNumber) (*hexutil.Uint64, error) {
-	e.logger.Debugln("eth_getTransactionCount", "address", address.Hex(), "block number", blockNum)
+	e.logger.Debug("eth_getTransactionCount", "address", address.Hex(), "block number", blockNum)
 
 	// Get nonce (sequence) from account
 	from := sdk.AccAddress(address.Bytes())
@@ -267,7 +268,7 @@ func (e *PublicAPI) GetTransactionCount(address common.Address, blockNum rpctype
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block identified by hash.
 func (e *PublicAPI) GetBlockTransactionCountByHash(hash common.Hash) *hexutil.Uint {
-	e.logger.Debugln("eth_getBlockTransactionCountByHash", "hash", hash.Hex())
+	e.logger.Debug("eth_getBlockTransactionCountByHash", "hash", hash.Hex())
 
 	resBlock, err := e.clientCtx.Client.BlockByHash(e.ctx, hash.Bytes())
 	if err != nil {
@@ -280,7 +281,7 @@ func (e *PublicAPI) GetBlockTransactionCountByHash(hash common.Hash) *hexutil.Ui
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block identified by number.
 func (e *PublicAPI) GetBlockTransactionCountByNumber(blockNum rpctypes.BlockNumber) *hexutil.Uint {
-	e.logger.Debugln("eth_getBlockTransactionCountByNumber", "block number", blockNum)
+	e.logger.Debug("eth_getBlockTransactionCountByNumber", "block number", blockNum)
 	resBlock, err := e.clientCtx.Client.Block(e.ctx, blockNum.TmHeight())
 	if err != nil {
 		return nil
@@ -302,7 +303,7 @@ func (e *PublicAPI) GetUncleCountByBlockNumber(blockNum rpctypes.BlockNumber) he
 
 // GetCode returns the contract code at the given address and block number.
 func (e *PublicAPI) GetCode(address common.Address, blockNumber rpctypes.BlockNumber) (hexutil.Bytes, error) { // nolint: interfacer
-	e.logger.Debugln("eth_getCode", "address", address.Hex(), "block number", blockNumber)
+	e.logger.Debug("eth_getCode", "address", address.Hex(), "block number", blockNumber)
 
 	req := &evmtypes.QueryCodeRequest{
 		Address: address.String(),
@@ -318,26 +319,26 @@ func (e *PublicAPI) GetCode(address common.Address, blockNumber rpctypes.BlockNu
 
 // GetTransactionLogs returns the logs given a transaction hash.
 func (e *PublicAPI) GetTransactionLogs(txHash common.Hash) ([]*ethtypes.Log, error) {
-	e.logger.Debugln("eth_getTransactionLogs", "hash", txHash)
+	e.logger.Debug("eth_getTransactionLogs", "hash", txHash)
 	return e.backend.GetTransactionLogs(txHash)
 }
 
 // Sign signs the provided data using the private key of address via Geth's signature standard.
 func (e *PublicAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
-	e.logger.Debugln("eth_sign", "address", address.Hex(), "data", common.Bytes2Hex(data))
+	e.logger.Debug("eth_sign", "address", address.Hex(), "data", common.Bytes2Hex(data))
 
 	from := sdk.AccAddress(address.Bytes())
 
 	_, err := e.clientCtx.Keyring.KeyByAddress(from)
 	if err != nil {
-		e.logger.Errorln("failed to find key in keyring", "address", address.String())
+		e.logger.Error("failed to find key in keyring", "address", address.String())
 		return nil, fmt.Errorf("%s; %s", keystore.ErrNoMatch, err.Error())
 	}
 
 	// Sign the requested hash with the wallet
 	signature, _, err := e.clientCtx.Keyring.SignByAddress(from, data)
 	if err != nil {
-		e.logger.Panicln("keyring.SignByAddress failed")
+		e.logger.Error("keyring.SignByAddress failed")
 		return nil, err
 	}
 
@@ -347,12 +348,12 @@ func (e *PublicAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil.By
 
 // SendTransaction sends an Ethereum transaction.
 func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, error) {
-	e.logger.Debugln("eth_sendTransaction", "args", args.String())
+	e.logger.Debug("eth_sendTransaction", "args", args.String())
 
 	// Look up the wallet containing the requested signer
 	_, err := e.clientCtx.Keyring.KeyByAddress(sdk.AccAddress(args.From.Bytes()))
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to find key in keyring", "address", args.From)
+		e.logger.Error("failed to find key in keyring", "address", args.From, "error", err.Error())
 		return common.Hash{}, fmt.Errorf("%s; %s", keystore.ErrNoMatch, err.Error())
 	}
 
@@ -364,7 +365,7 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 	msg := args.ToTransaction()
 
 	if err := msg.ValidateBasic(); err != nil {
-		e.logger.WithError(err).Debugln("tx failed basic validation")
+		e.logger.Debug("tx failed basic validation", "error", err.Error())
 		return common.Hash{}, err
 	}
 
@@ -373,38 +374,38 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 
 	// Sign transaction
 	if err := msg.Sign(signer, e.clientCtx.Keyring); err != nil {
-		e.logger.Debugln("failed to sign tx", "error", err)
+		e.logger.Debug("failed to sign tx", "error", err)
 		return common.Hash{}, err
 	}
 
 	// Assemble transaction from fields
 	builder, ok := e.clientCtx.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 	if !ok {
-		e.logger.WithError(err).Panicln("clientCtx.TxConfig.NewTxBuilder returns unsupported builder")
+		e.logger.Error("clientCtx.TxConfig.NewTxBuilder returns unsupported builder", "error", err.Error())
 	}
 
 	option, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
 	if err != nil {
-		e.logger.WithError(err).Panicln("codectypes.NewAnyWithValue failed to pack an obvious value")
+		e.logger.Error("codectypes.NewAnyWithValue failed to pack an obvious value", "error", err.Error())
 		return common.Hash{}, err
 	}
 
 	builder.SetExtensionOptions(option)
 	err = builder.SetMsgs(msg)
 	if err != nil {
-		e.logger.WithError(err).Panicln("builder.SetMsgs failed")
+		e.logger.Error("builder.SetMsgs failed", "error", err.Error())
 	}
 
 	// Query params to use the EVM denomination
 	res, err := e.queryClient.QueryClient.Params(e.ctx, &evmtypes.QueryParamsRequest{})
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to query evm params")
+		e.logger.Error("failed to query evm params", "error", err.Error())
 		return common.Hash{}, err
 	}
 
 	txData, err := evmtypes.UnpackTxData(msg.Data)
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to unpack tx data")
+		e.logger.Error("failed to unpack tx data", "error", err.Error())
 		return common.Hash{}, err
 	}
 
@@ -416,7 +417,7 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 	txEncoder := e.clientCtx.TxConfig.TxEncoder()
 	txBytes, err := txEncoder(builder.GetTx())
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to encode eth tx using default encoder")
+		e.logger.Error("failed to encode eth tx using default encoder", "error", err.Error())
 		return common.Hash{}, err
 	}
 
@@ -430,7 +431,7 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 		if err == nil {
 			err = errors.New(rsp.RawLog)
 		}
-		e.logger.WithError(err).Errorln("failed to broadcast tx")
+		e.logger.Error("failed to broadcast tx", "error", err.Error())
 		return txHash, err
 	}
 
@@ -440,53 +441,53 @@ func (e *PublicAPI) SendTransaction(args rpctypes.SendTxArgs) (common.Hash, erro
 
 // SendRawTransaction send a raw Ethereum transaction.
 func (e *PublicAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error) {
-	e.logger.Debugln("eth_sendRawTransaction", "data_len", len(data))
+	e.logger.Debug("eth_sendRawTransaction", "data_len", len(data))
 
 	// RLP decode raw transaction bytes
 	tx, err := e.clientCtx.TxConfig.TxDecoder()(data)
 	if err != nil {
-		e.logger.WithError(err).Errorln("transaction decoding failed")
+		e.logger.Error("transaction decoding failed", "error", err.Error())
 
 		return common.Hash{}, err
 	}
 
 	ethereumTx, isEthTx := tx.(*evmtypes.MsgEthereumTx)
 	if !isEthTx {
-		e.logger.Debugln("invalid transaction type", "type", fmt.Sprintf("%T", tx))
+		e.logger.Debug("invalid transaction type", "type", fmt.Sprintf("%T", tx))
 		return common.Hash{}, fmt.Errorf("invalid transaction type %T", tx)
 	}
 
 	if err := ethereumTx.ValidateBasic(); err != nil {
-		e.logger.WithError(err).Debugln("tx failed basic validation")
+		e.logger.Debug("tx failed basic validation", "error", err.Error())
 		return common.Hash{}, err
 	}
 
 	builder, ok := e.clientCtx.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 	if !ok {
-		e.logger.Panicln("clientCtx.TxConfig.NewTxBuilder returns unsupported builder")
+		e.logger.Error("clientCtx.TxConfig.NewTxBuilder returns unsupported builder")
 	}
 
 	option, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
 	if err != nil {
-		e.logger.WithError(err).Panicln("codectypes.NewAnyWithValue failed to pack an obvious value")
+		e.logger.Error("codectypes.NewAnyWithValue failed to pack an obvious value", "error", err.Error())
 	}
 
 	builder.SetExtensionOptions(option)
 	err = builder.SetMsgs(tx.GetMsgs()...)
 	if err != nil {
-		e.logger.WithError(err).Panicln("builder.SetMsgs failed")
+		e.logger.Error("builder.SetMsgs failed", "error", err.Error())
 	}
 
 	// Query params to use the EVM denomination
 	res, err := e.queryClient.QueryClient.Params(e.ctx, &evmtypes.QueryParamsRequest{})
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to query evm params")
+		e.logger.Error("failed to query evm params", "error", err.Error())
 		return common.Hash{}, err
 	}
 
 	txData, err := evmtypes.UnpackTxData(ethereumTx.Data)
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to unpack tx data")
+		e.logger.Error("failed to unpack tx data", "error", err.Error())
 		return common.Hash{}, err
 	}
 
@@ -497,7 +498,7 @@ func (e *PublicAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error) 
 	// Encode transaction by default Tx encoder
 	txBytes, err := e.clientCtx.TxConfig.TxEncoder()(builder.GetTx())
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to encode eth tx using default encoder")
+		e.logger.Error("failed to encode eth tx using default encoder", "error", err.Error())
 		return common.Hash{}, err
 	}
 
@@ -509,7 +510,7 @@ func (e *PublicAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error) 
 		if err == nil {
 			err = errors.New(rsp.RawLog)
 		}
-		e.logger.WithError(err).Errorln("failed to broadcast tx")
+		e.logger.Error("failed to broadcast tx", "error", err.Error())
 		return txHash, err
 	}
 
@@ -518,7 +519,7 @@ func (e *PublicAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error) 
 
 // Call performs a raw contract call.
 func (e *PublicAPI) Call(args evmtypes.CallArgs, blockNr rpctypes.BlockNumber, _ *rpctypes.StateOverride) (hexutil.Bytes, error) {
-	e.logger.Debugln("eth_call", "args", args.String(), "block number", blockNr)
+	e.logger.Debug("eth_call", "args", args.String(), "block number", blockNr)
 	data, err := e.doCall(args, blockNr)
 	if err != nil {
 		return []byte{}, err
@@ -553,7 +554,7 @@ func (e *PublicAPI) doCall(
 // It adds 1,000 gas to the returned value instead of using the gas adjustment
 // param from the SDK.
 func (e *PublicAPI) EstimateGas(args evmtypes.CallArgs) (hexutil.Uint64, error) {
-	e.logger.Debugln("eth_estimateGas")
+	e.logger.Debug("eth_estimateGas")
 
 	// From ContextWithHeight: if the provided height is 0,
 	// it will return an empty context and the gRPC query will use
@@ -572,13 +573,13 @@ func (e *PublicAPI) EstimateGas(args evmtypes.CallArgs) (hexutil.Uint64, error) 
 
 // GetBlockByHash returns the block identified by hash.
 func (e *PublicAPI) GetBlockByHash(hash common.Hash, fullTx bool) (map[string]interface{}, error) {
-	e.logger.Debugln("eth_getBlockByHash", "hash", hash.Hex(), "full", fullTx)
+	e.logger.Debug("eth_getBlockByHash", "hash", hash.Hex(), "full", fullTx)
 	return e.backend.GetBlockByHash(hash, fullTx)
 }
 
 // GetBlockByNumber returns the block identified by number.
 func (e *PublicAPI) GetBlockByNumber(ethBlockNum rpctypes.BlockNumber, fullTx bool) (map[string]interface{}, error) {
-	e.logger.Debugln("eth_getBlockByNumber", "number", ethBlockNum, "full", fullTx)
+	e.logger.Debug("eth_getBlockByNumber", "number", ethBlockNum, "full", fullTx)
 	return e.backend.GetBlockByNumber(ethBlockNum, fullTx)
 }
 
@@ -599,11 +600,11 @@ func (e *PublicAPI) GetTxByEthHash(hash common.Hash) (*tmrpctypes.ResultTx, erro
 
 // GetTransactionByHash returns the transaction identified by hash.
 func (e *PublicAPI) GetTransactionByHash(hash common.Hash) (*rpctypes.RPCTransaction, error) {
-	e.logger.Debugln("eth_getTransactionByHash", "hash", hash.Hex())
+	e.logger.Debug("eth_getTransactionByHash", "hash", hash.Hex())
 
 	res, err := e.GetTxByEthHash(hash)
 	if err != nil {
-		e.logger.WithError(err).Debugln("tx not found", "hash", hash.Hex())
+		e.logger.Debug("tx not found", "hash", hash.Hex(), "error", err.Error())
 
 		// try to find tx in mempool
 		txs, err := e.backend.PendingTransactions()
@@ -656,23 +657,23 @@ func (e *PublicAPI) GetTransactionByHash(hash common.Hash) (*rpctypes.RPCTransac
 
 	resBlock, err := e.clientCtx.Client.Block(e.ctx, &res.Height)
 	if err != nil {
-		e.logger.WithError(err).Debugln("block not found", "height", res.Height)
+		e.logger.Debug("block not found", "height", res.Height, "error", err.Error())
 		return nil, nil
 	}
 
 	tx, err := e.clientCtx.TxConfig.TxDecoder()(res.Tx)
 	if err != nil {
-		e.logger.WithError(err).Debugln("decoding failed")
+		e.logger.Debug("decoding failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to decode tx: %w", err)
 	}
 
 	if len(tx.GetMsgs()) != 1 {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 	msg, ok := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 	if !ok {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 
@@ -698,34 +699,34 @@ func (e *PublicAPI) GetTransactionByHash(hash common.Hash) (*rpctypes.RPCTransac
 
 // GetTransactionByBlockHashAndIndex returns the transaction identified by hash and index.
 func (e *PublicAPI) GetTransactionByBlockHashAndIndex(hash common.Hash, idx hexutil.Uint) (*rpctypes.RPCTransaction, error) {
-	e.logger.Debugln("eth_getTransactionByBlockHashAndIndex", "hash", hash.Hex(), "index", idx)
+	e.logger.Debug("eth_getTransactionByBlockHashAndIndex", "hash", hash.Hex(), "index", idx)
 
 	resBlock, err := e.clientCtx.Client.BlockByHash(e.ctx, hash.Bytes())
 	if err != nil {
-		e.logger.WithError(err).Debugln("block not found", "hash", hash.Hex())
+		e.logger.Debug("block not found", "hash", hash.Hex(), "error", err.Error())
 		return nil, nil
 	}
 
 	i := int(idx)
 	if i >= len(resBlock.Block.Txs) {
-		e.logger.Debugln("block txs index out of bound", "index", i)
+		e.logger.Debug("block txs index out of bound", "index", i)
 		return nil, nil
 	}
 
 	txBz := resBlock.Block.Txs[i]
 	tx, err := e.clientCtx.TxConfig.TxDecoder()(txBz)
 	if err != nil {
-		e.logger.WithError(err).Debugln("decoding failed")
+		e.logger.Debug("decoding failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to decode tx: %w", err)
 	}
 
 	if len(tx.GetMsgs()) != 1 {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 	msg, ok := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 	if !ok {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 
@@ -733,7 +734,7 @@ func (e *PublicAPI) GetTransactionByBlockHashAndIndex(hash common.Hash, idx hexu
 
 	txData, err := evmtypes.UnpackTxData(msg.Data)
 	if err != nil {
-		e.logger.WithError(err).Debugln("decoding failed")
+		e.logger.Debug("decoding failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to unpack tx data: %w", err)
 	}
 
@@ -749,34 +750,34 @@ func (e *PublicAPI) GetTransactionByBlockHashAndIndex(hash common.Hash, idx hexu
 
 // GetTransactionByBlockNumberAndIndex returns the transaction identified by number and index.
 func (e *PublicAPI) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockNumber, idx hexutil.Uint) (*rpctypes.RPCTransaction, error) {
-	e.logger.Debugln("eth_getTransactionByBlockNumberAndIndex", "number", blockNum, "index", idx)
+	e.logger.Debug("eth_getTransactionByBlockNumberAndIndex", "number", blockNum, "index", idx)
 
 	resBlock, err := e.clientCtx.Client.Block(e.ctx, blockNum.TmHeight())
 	if err != nil {
-		e.logger.WithError(err).Debugln("block not found", "height", blockNum.Int64())
+		e.logger.Debug("block not found", "height", blockNum.Int64(), "error", err.Error())
 		return nil, nil
 	}
 
 	i := int(idx)
 	if i >= len(resBlock.Block.Txs) {
-		e.logger.Debugln("block txs index out of bound", "index", i)
+		e.logger.Debug("block txs index out of bound", "index", i)
 		return nil, nil
 	}
 
 	txBz := resBlock.Block.Txs[i]
 	tx, err := e.clientCtx.TxConfig.TxDecoder()(txBz)
 	if err != nil {
-		e.logger.WithError(err).Debugln("decoding failed")
+		e.logger.Debug("decoding failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to decode tx: %w", err)
 	}
 
 	if len(tx.GetMsgs()) != 1 {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 	msg, ok := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 	if !ok {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 
@@ -784,7 +785,7 @@ func (e *PublicAPI) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockN
 
 	txData, err := evmtypes.UnpackTxData(msg.Data)
 	if err != nil {
-		e.logger.WithError(err).Debugln("decoding failed")
+		e.logger.Debug("decoding failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to unpack tx data: %w", err)
 	}
 
@@ -800,47 +801,47 @@ func (e *PublicAPI) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockN
 
 // GetTransactionReceipt returns the transaction receipt identified by hash.
 func (e *PublicAPI) GetTransactionReceipt(hash common.Hash) (map[string]interface{}, error) {
-	e.logger.Debugln("eth_getTransactionReceipt", "hash", hash.Hex())
+	e.logger.Debug("eth_getTransactionReceipt", "hash", hash.Hex())
 
 	res, err := e.GetTxByEthHash(hash)
 	if err != nil {
-		e.logger.WithError(err).Debugln("tx not found", "hash", hash.Hex())
+		e.logger.Debug("tx not found", "hash", hash.Hex(), "error", err.Error())
 		return nil, nil
 	}
 
 	resBlock, err := e.clientCtx.Client.Block(e.ctx, &res.Height)
 	if err != nil {
-		e.logger.WithError(err).Debugln("block not found", "height", res.Height)
+		e.logger.Debug("block not found", "height", res.Height, "error", err.Error())
 		return nil, nil
 	}
 
 	tx, err := e.clientCtx.TxConfig.TxDecoder()(res.Tx)
 	if err != nil {
-		e.logger.WithError(err).Debugln("decoding failed")
+		e.logger.Debug("decoding failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to decode tx: %w", err)
 	}
 
 	if len(tx.GetMsgs()) != 1 {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 
 	msg, ok := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 	if !ok {
-		e.logger.Debugln("invalid tx")
+		e.logger.Debug("invalid tx")
 		return nil, fmt.Errorf("invalid tx type: %T", tx)
 	}
 
 	txData, err := evmtypes.UnpackTxData(msg.Data)
 	if err != nil {
-		e.logger.WithError(err).Errorln("failed to unpack tx data")
+		e.logger.Error("failed to unpack tx data", "error", err.Error())
 		return nil, err
 	}
 
 	cumulativeGasUsed := uint64(0)
 	blockRes, err := e.clientCtx.Client.BlockResults(e.ctx, &res.Height)
 	if err != nil {
-		e.logger.WithError(err).Debugln("failed to retrieve block results", "height", res.Height)
+		e.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
 		return nil, nil
 	}
 
@@ -863,7 +864,7 @@ func (e *PublicAPI) GetTransactionReceipt(hash common.Hash) (map[string]interfac
 
 	resLogs, err := e.queryClient.TxLogs(e.ctx, &evmtypes.QueryTxLogsRequest{Hash: hash.Hex()})
 	if err != nil {
-		e.logger.WithError(err).Debugln("logs not found", "hash", hash.Hex())
+		e.logger.Debug("logs not found", "hash", hash.Hex(), "error", err.Error())
 		resLogs = &evmtypes.QueryTxLogsResponse{Logs: []*evmtypes.Log{}}
 	}
 
@@ -909,7 +910,7 @@ func (e *PublicAPI) GetTransactionReceipt(hash common.Hash) (map[string]interfac
 // PendingTransactions returns the transactions that are in the transaction pool
 // and have a from address that is one of the accounts this node manages.
 func (e *PublicAPI) PendingTransactions() ([]*rpctypes.RPCTransaction, error) {
-	e.logger.Debugln("eth_getPendingTransactions")
+	e.logger.Debug("eth_getPendingTransactions")
 
 	// FIXME https://github.com/tharsis/ethermint/issues/244
 	return []*rpctypes.RPCTransaction{}, nil
@@ -928,7 +929,7 @@ func (e *PublicAPI) GetUncleByBlockNumberAndIndex(number hexutil.Uint, idx hexut
 // GetProof returns an account object with proof and any storage proofs
 func (e *PublicAPI) GetProof(address common.Address, storageKeys []string, blockNumber rpctypes.BlockNumber) (*rpctypes.AccountResult, error) {
 	height := blockNumber.Int64()
-	e.logger.Debugln("eth_getProof", "address", address.Hex(), "keys", storageKeys, "number", height)
+	e.logger.Debug("eth_getProof", "address", address.Hex(), "keys", storageKeys, "number", height)
 
 	ctx := rpctypes.ContextWithHeight(height)
 	clientCtx := e.clientCtx.WithHeight(height)
@@ -1053,7 +1054,7 @@ func (e *PublicAPI) setTxDefaults(args rpctypes.SendTxArgs) (rpctypes.SendTxArgs
 			return args, err
 		}
 		args.Gas = &estimated
-		e.logger.Debugln("estimate gas usage automatically", "gas", args.Gas)
+		e.logger.Debug("estimate gas usage automatically", "gas", args.Gas)
 	}
 
 	if args.ChainID == nil {
@@ -1088,7 +1089,7 @@ func (e *PublicAPI) getAccountNonce(accAddr common.Address, pending bool, height
 	// to manually add them.
 	pendingTxs, err := e.backend.PendingTransactions()
 	if err != nil {
-		logger.WithError(err).Errorln("fails to fetch pending transactions")
+		logger.Error("fails to fetch pending transactions", "error", err.Error())
 		return nonce, nil
 	}
 

--- a/ethereum/rpc/namespaces/eth/filters/filter_system.go
+++ b/ethereum/rpc/namespaces/eth/filters/filter_system.go
@@ -65,6 +65,7 @@ func NewEventSystem(logger log.Logger, tmWSClient *rpcclient.WSClient) *EventSys
 	}
 
 	es := &EventSystem{
+		logger:     logger,
 		ctx:        context.Background(),
 		tmWSClient: tmWSClient,
 		lightMode:  false,

--- a/ethereum/rpc/namespaces/eth/filters/filter_system.go
+++ b/ethereum/rpc/namespaces/eth/filters/filter_system.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	log "github.com/xlab/suplog"
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
+	"github.com/tendermint/tendermint/libs/log"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
@@ -35,6 +35,7 @@ var (
 // EventSystem creates subscriptions, processes events and broadcasts them to the
 // subscription which match the subscription criteria using the Tendermint's RPC client.
 type EventSystem struct {
+	logger     log.Logger
 	ctx        context.Context
 	tmWSClient *rpcclient.WSClient
 
@@ -57,7 +58,7 @@ type EventSystem struct {
 //
 // The returned manager has a loop that needs to be stopped with the Stop function
 // or by stopping the given mux.
-func NewEventSystem(tmWSClient *rpcclient.WSClient) *EventSystem {
+func NewEventSystem(logger log.Logger, tmWSClient *rpcclient.WSClient) *EventSystem {
 	index := make(filterIndex)
 	for i := filters.UnknownSubscription; i < filters.LastIndexSubscription; i++ {
 		index[i] = make(map[rpc.ID]*Subscription)
@@ -222,7 +223,7 @@ func (es *EventSystem) eventLoop() {
 			ch := make(chan coretypes.ResultEvent)
 			es.topicChans[f.event] = ch
 			if err := es.eventBus.AddTopic(f.event, ch); err != nil {
-				log.WithField("topic", f.event).WithError(err).Errorln("failed to add event topic to event bus")
+				es.logger.Error("failed to add event topic to event bus", "topic", f.event, "error", err.Error())
 			}
 			es.indexMux.Unlock()
 			close(f.installed)
@@ -241,7 +242,7 @@ func (es *EventSystem) eventLoop() {
 			// remove topic only when channel is not used by other subscriptions
 			if !channelInUse {
 				if err := es.tmWSClient.Unsubscribe(es.ctx, f.event); err != nil {
-					log.WithError(err).WithField("query", f.event).Errorln("failed to unsubscribe from query")
+					es.logger.Error("failed to unsubscribe from query", "query", f.event, "error", err.Error())
 				}
 
 				ch, ok := es.topicChans[f.event]
@@ -267,7 +268,7 @@ func (es *EventSystem) consumeEvents() {
 				time.Sleep(5 * time.Second)
 				continue
 			} else if err := tmjson.Unmarshal(rpcResp.Result, &ev); err != nil {
-				log.WithError(err).Warningln("failed to JSON unmarshal ResponsesCh result event")
+				es.logger.Error("failed to JSON unmarshal ResponsesCh result event", "error", err.Error())
 				continue
 			}
 
@@ -280,8 +281,8 @@ func (es *EventSystem) consumeEvents() {
 			ch, ok := es.topicChans[ev.Query]
 			es.indexMux.RUnlock()
 			if !ok {
-				log.WithField("topic", ev.Query).Warningln("channel for subscription not found, lol")
-				log.Infoln("available channels:", es.eventBus.Topics())
+				es.logger.Debug("channel for subscription not found", "topic", ev.Query)
+				es.logger.Debug("list of available channels", "channels", es.eventBus.Topics())
 				continue
 			}
 
@@ -289,7 +290,7 @@ func (es *EventSystem) consumeEvents() {
 			t := time.NewTimer(time.Second)
 			select {
 			case <-t.C:
-				log.WithField("topic", ev.Query).Warningln("dropped event during lagging subscription")
+				es.logger.Debug("dropped event during lagging subscription", "topic", ev.Query)
 			case ch <- ev:
 			}
 		}

--- a/ethereum/rpc/namespaces/personal/api.go
+++ b/ethereum/rpc/namespaces/personal/api.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tharsis/ethermint/crypto/hd"
 	ethermint "github.com/tharsis/ethermint/types"
 
-	log "github.com/xlab/suplog"
+	"github.com/tendermint/tendermint/libs/log"
 
 	sdkcrypto "github.com/cosmos/cosmos-sdk/crypto"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -32,10 +32,10 @@ type PrivateAccountAPI struct {
 }
 
 // NewAPI creates an instance of the public Personal Eth API.
-func NewAPI(ethAPI *eth.PublicAPI) *PrivateAccountAPI {
+func NewAPI(logger log.Logger, ethAPI *eth.PublicAPI) *PrivateAccountAPI {
 	return &PrivateAccountAPI{
 		ethAPI: ethAPI,
-		logger: log.WithField("module", "personal"),
+		logger: logger.With("api", "personal"),
 	}
 }
 
@@ -96,7 +96,7 @@ func (api *PrivateAccountAPI) ListAccounts() ([]common.Address, error) {
 // LockAccount will lock the account associated with the given address when it's unlocked.
 // It removes the key corresponding to the given address from the API's local keys.
 func (api *PrivateAccountAPI) LockAccount(address common.Address) bool { // nolint: interfacer
-	api.logger.Debugln("personal_lockAccount", "address", address.String())
+	api.logger.Debug("personal_lockAccount", "address", address.String())
 	api.logger.Info("personal_lockAccount not supported")
 	// TODO: Not supported. See underlying issue  https://github.com/99designs/keyring/issues/85
 	return false
@@ -115,9 +115,9 @@ func (api *PrivateAccountAPI) NewAccount(password string) (common.Address, error
 	}
 
 	addr := common.BytesToAddress(info.GetPubKey().Address().Bytes())
-	api.logger.Infoln("Your new key was generated", "address", addr.String())
-	api.logger.Infoln("Please backup your key file!", "path", os.Getenv("HOME")+"/.ethermint/"+name)
-	api.logger.Infoln("Please remember your password!")
+	api.logger.Info("Your new key was generated", "address", addr.String())
+	api.logger.Info("Please backup your key file!", "path", os.Getenv("HOME")+"/.ethermint/"+name)
+	api.logger.Info("Please remember your password!")
 	return addr, nil
 }
 
@@ -125,7 +125,7 @@ func (api *PrivateAccountAPI) NewAccount(password string) (common.Address, error
 // the given password for duration seconds. If duration is nil it will use a
 // default of 300 seconds. It returns an indication if the account was unlocked.
 func (api *PrivateAccountAPI) UnlockAccount(_ context.Context, addr common.Address, _ string, _ *uint64) (bool, error) { // nolint: interfacer
-	api.logger.Debugln("personal_unlockAccount", "address", addr.String())
+	api.logger.Debug("personal_unlockAccount", "address", addr.String())
 	// TODO: Not supported. See underlying issue  https://github.com/99designs/keyring/issues/85
 	return false, nil
 }
@@ -154,7 +154,7 @@ func (api *PrivateAccountAPI) Sign(_ context.Context, data hexutil.Bytes, addr c
 
 	sig, _, err := api.ethAPI.ClientCtx().Keyring.SignByAddress(cosmosAddr, accounts.TextHash(data))
 	if err != nil {
-		api.logger.WithError(err).Debugln("failed to sign with key", "data", data, "address", addr.String())
+		api.logger.Error("failed to sign with key", "data", data, "address", addr.String(), "error", err.Error())
 		return nil, err
 	}
 

--- a/ethereum/rpc/namespaces/txpool/api.go
+++ b/ethereum/rpc/namespaces/txpool/api.go
@@ -1,9 +1,11 @@
 package txpool
 
 import (
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/tharsis/ethermint/ethereum/rpc/types"
-	log "github.com/xlab/suplog"
 )
 
 // PublicAPI offers and API for the transaction pool. It only operates on data that is non-confidential.
@@ -13,9 +15,9 @@ type PublicAPI struct {
 }
 
 // NewPublicAPI creates a new tx pool service that gives information about the transaction pool.
-func NewPublicAPI() *PublicAPI {
+func NewPublicAPI(logger log.Logger) *PublicAPI {
 	return &PublicAPI{
-		logger: log.WithField("module", "txpool"),
+		logger: logger.With("module", "txpool"),
 	}
 }
 

--- a/tests/solidity/init-test-node.sh
+++ b/tests/solidity/init-test-node.sh
@@ -40,4 +40,4 @@ ethermintd collect-gentxs
 ethermintd validate-genesis
 
 # Start the node (remove the --pruning=nothing flag if historical queries are not needed)
-ethermintd start --pruning=nothing --rpc.unsafe --keyring-backend test --trace --log_level "info"
+ethermintd start --pruning=nothing --rpc.unsafe --keyring-backend test --trace --log_level info

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -121,7 +121,7 @@ func startInProcess(cfg Config, val *Validator) error {
 
 		val.jsonRPC = jsonrpc.NewServer()
 
-		apis := rpc.GetRPCAPIs(val.ClientCtx, tmWsClient)
+		apis := rpc.GetRPCAPIs(val.Ctx, val.ClientCtx, tmWsClient)
 		for _, api := range apis {
 			if err := val.jsonRPC.RegisterName(api.Namespace, api.Service); err != nil {
 				return fmt.Errorf("failed to register JSON-RPC namespace %s: %w", api.Namespace, err)


### PR DESCRIPTION
closes #262

there are still some logs from the log go-ethereum library that doesn't have a function for defining log level on the RPC handler