### PR TITLE
fix order of eip activation

### DIFF
--- a/x/evm/types/params.go
+++ b/x/evm/types/params.go
@@ -24,6 +24,11 @@ var (
 	ParamStoreKeyEnableCall   = []byte("EnableCall")
 	ParamStoreKeyExtraEIPs    = []byte("EnableExtraEIPs")
 	ParamStoreKeyChainConfig  = []byte("ChainConfig")
+
+	// AvailableExtraEIPs define the list of all EIPs that can be enabled by the EVM interpreter. These EIPs are applied in
+	// order and can override the instruction sets from the latest hard fork enabled by the ChainConfig. For more info
+	// check: https://github.com/ethereum/go-ethereum/blob/v1.10.4/core/vm/interpreter.go#L122
+	AvailableExtraEIPs = []int64{1344, 1884, 2200, 2929}
 )
 
 // ParamKeyTable returns the parameter key table.
@@ -43,13 +48,14 @@ func NewParams(evmDenom string, enableCreate, enableCall bool, config ChainConfi
 }
 
 // DefaultParams returns default evm parameters
+// ExtraEIPs is empty to prevent overriding the latest hard fork instruction set
 func DefaultParams() Params {
 	return Params{
 		EvmDenom:     DefaultEVMDenom,
 		EnableCreate: true,
 		EnableCall:   true,
-		ExtraEIPs:    []int64{2929, 2200, 1884, 1344},
 		ChainConfig:  DefaultChainConfig(),
+		ExtraEIPs:    nil,
 	}
 }
 


### PR DESCRIPTION
Closes: #287

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Remove the extra eips since we already activated Berlin hardfork in chain config.

Why wrong order cause issue:
- eip1884 set `SLOAD`'s constant gas to 800, without touch dynamic gas
- eip2929 change `SLOAD` to use dynamic gas(2100 for cold access) and set constant gas to zero

So in the right order, the end result is 2100, but in reverse order, we get 2900.

Verified in external integration test.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
