### PR TITLE
Feat: Configurable RPC Apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (rpc) [tharsis#176](https://github.com/tharsis/ethermint/issues/176) Support fetching pending nonce
 * (rpc) [tharsis#272](https://github.com/tharsis/ethermint/pull/272) do binary search to estimate gas accurately
 * (rpc) [#313](https://github.com/tharsis/ethermint/pull/313) Implement internal debug namespace (Not including logger functions nor traces).
+* (rpc) [#313](https://github.com/tharsis/ethermint/pull/313) Implement internal debug namespace (Not including logger functions nor traces).
 
 ### Bug Fixes
 

--- a/cmd/ethermintd/config/config.go
+++ b/cmd/ethermintd/config/config.go
@@ -57,23 +57,26 @@ func DefaultConfig() *Config {
 	}
 }
 
-// DefaultEVMConfig returns an EVM config with the JSON-RPC API enabled by default
-func DefaultEVMConfig() *EVMRPCConfig {
-	return &EVMRPCConfig{
-		Enable:     true,
-		RPCAddress: DefaultEVMAddress,
-		WsAddress:  DefaultEVMWSAddress,
-	}
-}
-
 // EVMRPCConfig defines configuration for the EVM RPC server.
 type EVMRPCConfig struct {
 	// Enable defines if the EVM RPC server should be enabled.
 	Enable bool `mapstructure:"enable"`
+	// Api defines the api namespaces that should be enabled
+	API string `mapstructure:"api"`
 	// Address defines the HTTP server to listen on
 	RPCAddress string `mapstructure:"address"`
 	// Address defines the WebSocket server to listen on
 	WsAddress string `mapstructure:"ws-address"`
+}
+
+// DefaultEVMConfig returns an EVM config with the JSON-RPC API enabled by default
+func DefaultEVMConfig() *EVMRPCConfig {
+	return &EVMRPCConfig{
+		Enable:     true,
+		API:        "",
+		RPCAddress: DefaultEVMAddress,
+		WsAddress:  DefaultEVMWSAddress,
+	}
 }
 
 // Config defines the server's top level configuration. It includes the default app config
@@ -93,6 +96,7 @@ func GetConfig(v *viper.Viper) Config {
 		Config: cfg,
 		EVMRPC: EVMRPCConfig{
 			Enable:     v.GetBool("evm-rpc.enable"),
+			API:        v.GetString("evm-rpc.api"),
 			RPCAddress: v.GetString("evm-rpc.address"),
 			WsAddress:  v.GetString("evm-rpc.ws-address"),
 		},

--- a/docs/basics/json_rpc.md
+++ b/docs/basics/json_rpc.md
@@ -11,6 +11,16 @@ Check the JSON-RPC methods and namespaces supported on Ethermint. {synopsis}
 - [Ethereum JSON-RPC](https://eth.wiki/json-rpc/API) {prereq}
 - [Geth JSON-RPC APIs](https://geth.ethereum.org/docs/rpc/server) {prereq}
 
+## JSON-RPC Server
+
+To enable RPC server use the following flag (set to true by default).
+
+```ethermintd start --grpc.enable```
+
+By default, only `eth` namespace is enabled. In order to enable other namespaces use flag `--evm-rpc.api`.
+
+```ethermintd start --evm-rpc.api txpool,personal,net,debug,web3```
+
 ## JSON-RPC Methods
 
 | Method                                                                            | Namespace | Implemented | Notes                     |

--- a/ethereum/rpc/apis.go
+++ b/ethereum/rpc/apis.go
@@ -35,8 +35,8 @@ const (
 // GetRPCAPIs returns the list of all APIs
 func GetRPCAPIs(ctx *server.Context, clientCtx client.Context, tmWSClient *rpcclient.WSClient) []rpc.API {
 	nonceLock := new(types.AddrLocker)
-	backend := backend.NewEVMBackend(ctx.Logger, clientCtx)
-	ethAPI := eth.NewPublicAPI(ctx.Logger, clientCtx, backend, nonceLock)
+	evmBackend := backend.NewEVMBackend(ctx.Logger, clientCtx)
+	ethAPI := eth.NewPublicAPI(ctx.Logger, clientCtx, evmBackend, nonceLock)
 
 	return []rpc.API{
 		{
@@ -54,7 +54,7 @@ func GetRPCAPIs(ctx *server.Context, clientCtx client.Context, tmWSClient *rpccl
 		{
 			Namespace: EthNamespace,
 			Version:   apiVersion,
-			Service:   filters.NewPublicAPI(ctx.Logger, tmWSClient, backend),
+			Service:   filters.NewPublicAPI(ctx.Logger, tmWSClient, evmBackend),
 			Public:    true,
 		},
 		{

--- a/init.sh
+++ b/init.sh
@@ -84,4 +84,4 @@ if [[ $1 == "pending" ]]; then
 fi
 
 # Start the node (remove the --pruning=nothing flag if historical queries are not needed)
-ethermintd start --pruning=nothing $TRACE --log_level $LOGLEVEL --minimum-gas-prices=0.0001aphoton
+ethermintd start --pruning=nothing $TRACE --log_level $LOGLEVEL --minimum-gas-prices=0.0001aphoton --evm-rpc.api txpool,personal,net,debug,web3

--- a/server/start.go
+++ b/server/start.go
@@ -153,10 +153,10 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Uint64(FlagMinRetainBlocks, 0, "Minimum block height offset during ABCI commit to prune Tendermint blocks")
 
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")
-	cmd.Flags().String(flagEVMRPCAPI, "", "Defined which gRPC namespace should be enabled")
 	cmd.Flags().String(flagGRPCAddress, config.DefaultGRPCAddress, "the gRPC server address to listen on")
 
 	cmd.Flags().Bool(flagEVMRPCEnable, true, "Define if the gRPC server should be enabled")
+	cmd.Flags().String(flagEVMRPCAPI, "", "Defined which gRPC namespace should be enabled")
 	cmd.Flags().String(flagEVMRPCAddress, config.DefaultEVMAddress, "the EVM RPC server address to listen on")
 	cmd.Flags().String(flagEVMWSAddress, config.DefaultEVMWSAddress, "the EVM WS server address to listen on")
 

--- a/tests/solidity/init-test-node.sh
+++ b/tests/solidity/init-test-node.sh
@@ -43,4 +43,4 @@ ethermintd collect-gentxs
 ethermintd validate-genesis
 
 # Start the node (remove the --pruning=nothing flag if historical queries are not needed)
-ethermintd start --pruning=nothing --rpc.unsafe --keyring-backend test --trace --log_level info
+ethermintd start --pruning=nothing --rpc.unsafe --keyring-backend test --trace --log_level info --evm-rpc.api txpool,personal,net,debug,web3

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -121,7 +121,11 @@ func startInProcess(cfg Config, val *Validator) error {
 
 		val.jsonRPC = jsonrpc.NewServer()
 
-		apis := rpc.GetRPCAPIs(val.Ctx, val.ClientCtx, tmWsClient)
+		rpcApi := val.AppConfig.EVMRPC.API
+		rpcApi = strings.ReplaceAll(rpcApi, " ", "")
+		rpcApiArr := strings.Split(rpcApi, ",")
+
+		apis := rpc.GetRPCAPIs(val.Ctx, val.ClientCtx, tmWsClient, rpcApiArr)
 		for _, api := range apis {
 			if err := val.jsonRPC.RegisterName(api.Namespace, api.Service); err != nil {
 				return fmt.Errorf("failed to register JSON-RPC namespace %s: %w", api.Namespace, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #174 

## Description

Given that we now support some debug endpoints. It is necessary to allow nodes to enable the desired api namespaces to avoid undesired stress on the nodes from expensive requests.

This PR just enables to specify which namespaces to have open from the namespaces that we support. Left `eth` namespace open by default.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
