### PR TITLE
fix viper parse app.toml

### DIFF
--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -18,7 +18,8 @@ address = "{{ .EVMRPC.RPCAddress }}"
 ws-address = "{{ .EVMRPC.WsAddress }}"
 
 # API defines a list of JSON-RPC namespaces that should be enabled
-api = "{{ .EVMRPC.API }}"
+# Example: "eth,txpool,personal,net,debug,web3"
+api = "{{range $index, $elmt := .EVMRPC.API}}{{if $index}},{{$elmt}}{{else}}{{$elmt}}{{end}}{{end}}"
 
 # EnableUnsafeCORS defines if CORS should be enabled (unsafe - use it at your own risk)
 enable-unsafe-cors = "{{ .EVMRPC.EnableUnsafeCORS }}"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #382

## Description

Viper has an issue reading string slice from environment variable when a flag with same value is defined (when no flag is defined, then there is no bug)
https://github.com/spf13/viper/issues/380

for example 
`["api", "personnal", "debug"]` would be parse to an array of length 1  with value [ "[api personnal debug]"]

Correct result should be ["api", "personnal", "debug"]


There is currently no fix for this issue yet, so I had to change the way we define the api in the app.toml

Using this trick, the parse will be successfull

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
