### PR TITLE
client: catch and return unhandled errors in InitConfig

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -23,7 +23,13 @@ func InitConfig(cmd *cobra.Command) error {
 	}
 
 	configFile := path.Join(home, "config", "config.toml")
-	if _, err := os.Stat(configFile); err == nil {
+	_, err = os.Stat(configFile)
+	if err != nil && !os.IsNotExist(err) {
+		// Immediately return if the error isn't related to the file not existing.
+		// See issue https://github.com/tharsis/ethermint/issues/539
+		return err
+	}
+	if err == nil {
 		viper.SetConfigFile(configFile)
 
 		if err := viper.ReadInConfig(); err != nil {

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+func TestInitConfigNonNotExistError(t *testing.T) {
+	tempDir := t.TempDir()
+	subDir := filepath.Join(tempDir, "nonPerms")
+	if err := os.Mkdir(subDir, 0600); err != nil {
+		t.Fatalf("Failed to create sub directory: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().String(flags.FlagHome, "", "")
+	if err := cmd.PersistentFlags().Set(flags.FlagHome, subDir); err != nil {
+		t.Fatalf("Could not set home flag [%T] %v", err, err)
+	}
+
+	if err := InitConfig(cmd); !os.IsPermission(err) {
+		t.Fatalf("Failed to catch permissions error, got: [%T] %v", err, err)
+	}
+}


### PR DESCRIPTION
## Description

Catches and returns unhandled errors after stat-ing for the config file,
which is currently assuming that on non-existent error returned.

Fixes #539

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
