### PR TITLE
server: add missing db.Close calls before returning

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -164,6 +164,11 @@ func startStandAlone(ctx *server.Context, appCreator types.AppCreator) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			ctx.Logger.With("error", err).Error("error closing db")
+		}
+	}()
 
 	traceWriterFile := ctx.Viper.GetString(srvflags.TraceStore)
 	traceWriter, err := openTraceWriter(traceWriterFile)
@@ -226,6 +231,11 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, appCreator ty
 		logger.Error("failed to open DB", "error", err.Error())
 		return err
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			ctx.Logger.With("error", err).Error("error closing db")
+		}
+	}()
 
 	traceWriter, err := openTraceWriter(traceWriterFile)
 	if err != nil {


### PR DESCRIPTION
## Description

It's better to always close the db before exit, so we will be noticed
when any error happens. Otherwise, serious errors can silently happen,
e.g, corrupted db, pending write missing ...

Fixes #538

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
