### PR TITLE
fix: use global []byte slice to avoid sring -> []byte conversions in loop

### DIFF
--- a/ethereum/rpc/backend/backend.go
+++ b/ethereum/rpc/backend/backend.go
@@ -67,6 +67,8 @@ type Backend interface {
 
 var _ Backend = (*EVMBackend)(nil)
 
+var bAttributeKeyEthereumBloom = []byte(evmtypes.AttributeKeyEthereumBloom)
+
 // EVMBackend implements the Backend interface
 type EVMBackend struct {
 	ctx         context.Context
@@ -205,7 +207,7 @@ func (e *EVMBackend) BlockBloom(height *int64) (ethtypes.Bloom, error) {
 		}
 
 		for _, attr := range event.Attributes {
-			if bytes.Equal(attr.Key, []byte(evmtypes.AttributeKeyEthereumBloom)) {
+			if bytes.Equal(attr.Key, bAttributeKeyEthereumBloom) {
 				return ethtypes.BytesToBloom(attr.Value), nil
 			}
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #573

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Instead of doing multiple conversions in the loop, use a global []byte slice of evmtypes.AttributeKeyEthereumBloom.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
