### PR TITLE
fix: don't revert gas refund logic when transaction reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (evm, ante) [tharsis#620](https://github.com/tharsis/ethermint/pull/620) Add fee market field to EVM `Keeper` and `AnteHandler`.
 * (all) [tharsis#231](https://github.com/tharsis/ethermint/pull/231) Bump go-ethereum version to [`v1.10.9`](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.9)
 * (ante) [tharsis#703](https://github.com/tharsis/ethermint/pull/703) Fix some fields in transaction are not authenticated by signature.
+* (evm) [tharsis#751](https://github.com/tharsis/ethermint/pull/751) don't revert gas refund logic when transaction reverted
 
 ### Features
 

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -526,7 +526,7 @@ func (suite *EvmTestSuite) TestErrorWhenDeployContract() {
 	// TODO: snapshot checking
 }
 
-func (suite *EvmTestSuite) deployTestRevertContract() common.Address {
+func (suite *EvmTestSuite) deployERC20Contract() common.Address {
 	k := suite.app.EvmKeeper
 	nonce := k.GetNonce(suite.from)
 	ctorArgs, err := types.ERC20Contract.ABI.Pack("", suite.from, big.NewInt(0))
@@ -550,6 +550,7 @@ func (suite *EvmTestSuite) deployTestRevertContract() common.Address {
 	return crypto.CreateAddress(suite.from, nonce)
 }
 
+// TestGasRefundWhenReverted check that when transaction reverted, gas refund should still work.
 func (suite *EvmTestSuite) TestGasRefundWhenReverted() {
 	suite.SetupTest()
 	k := suite.app.EvmKeeper
@@ -560,7 +561,7 @@ func (suite *EvmTestSuite) TestGasRefundWhenReverted() {
 	// add some fund to pay gas fee
 	k.AddBalance(suite.from, big.NewInt(10000000000))
 
-	contract := suite.deployTestRevertContract()
+	contract := suite.deployERC20Contract()
 
 	// the call will fail because no balance
 	data, err := types.ERC20Contract.ABI.Pack("transfer", common.BigToAddress(big.NewInt(1)), big.NewInt(10))

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -525,3 +525,84 @@ func (suite *EvmTestSuite) TestErrorWhenDeployContract() {
 
 	// TODO: snapshot checking
 }
+
+func (suite *EvmTestSuite) deployTestRevertContract() common.Address {
+	k := suite.app.EvmKeeper
+	nonce := k.GetNonce(suite.from)
+	ctorArgs, err := types.ERC20Contract.ABI.Pack("", suite.from, big.NewInt(0))
+	suite.Require().NoError(err)
+	msg := ethtypes.NewMessage(
+		suite.from,
+		nil,
+		nonce,
+		big.NewInt(0),
+		2000000,
+		big.NewInt(1),
+		nil,
+		nil,
+		append(types.ERC20Contract.Bin, ctorArgs...),
+		nil,
+		true,
+	)
+	rsp, err := k.ApplyMessage(msg, nil, true)
+	suite.Require().NoError(err)
+	suite.Require().False(rsp.Failed())
+	return crypto.CreateAddress(suite.from, nonce)
+}
+
+func (suite *EvmTestSuite) TestGasRefundWhenReverted() {
+	suite.SetupTest()
+	k := suite.app.EvmKeeper
+
+	// the bug only reproduce when there are hooks
+	k.SetHooks(&DummyHook{})
+
+	// add some fund to pay gas fee
+	k.AddBalance(suite.from, big.NewInt(10000000000))
+
+	contract := suite.deployTestRevertContract()
+
+	// the call will fail because no balance
+	data, err := types.ERC20Contract.ABI.Pack("transfer", common.BigToAddress(big.NewInt(1)), big.NewInt(10))
+	suite.Require().NoError(err)
+
+	tx := types.NewTx(
+		suite.chainID,
+		k.GetNonce(suite.from),
+		&contract,
+		big.NewInt(0),
+		41000,
+		big.NewInt(1),
+		nil,
+		nil,
+		data,
+		nil,
+	)
+	tx.From = suite.from.String()
+	err = tx.Sign(suite.ethSigner, suite.signer)
+	suite.Require().NoError(err)
+
+	before := k.GetBalance(suite.from)
+
+	txData, err := types.UnpackTxData(tx.Data)
+	suite.Require().NoError(err)
+	_, err = k.DeductTxCostsFromUserBalance(suite.ctx, *tx, txData, "aphoton", true, true, true)
+	suite.Require().NoError(err)
+
+	res, err := k.EthereumTx(sdk.WrapSDKContext(suite.ctx), tx)
+	suite.Require().NoError(err)
+	suite.Require().True(res.Failed())
+
+	after := k.GetBalance(suite.from)
+
+	suite.Require().Equal(uint64(21861), res.GasUsed)
+	// check gas refund works
+	suite.Require().Equal(big.NewInt(21861), new(big.Int).Sub(before, after))
+}
+
+// DummyHook implements EvmHooks interface
+type DummyHook struct{}
+
+func (dh *DummyHook) PostTxProcessing(ctx sdk.Context, txHash common.Hash, logs []*ethtypes.Log) error {
+	return nil
+}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -218,12 +218,6 @@ func (k *Keeper) ApplyTransaction(tx *ethtypes.Transaction) (*types.MsgEthereumT
 		return nil, stacktrace.Propagate(err, "failed to apply ethereum core message")
 	}
 
-	// refund gas prior to handling the vm error in order to match the Ethereum gas consumption instead of the default SDK one.
-	err = k.RefundGas(msg, msg.Gas()-res.GasUsed, cfg.Params.EvmDenom)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "failed to refund gas leftover gas to sender %s", msg.From())
-	}
-
 	res.Hash = txHash.Hex()
 
 	logs := k.GetTxLogsTransient(txHash)
@@ -239,6 +233,15 @@ func (k *Keeper) ApplyTransaction(tx *ethtypes.Transaction) (*types.MsgEthereumT
 			commit()
 			ctx.EventManager().EmitEvents(k.Ctx().EventManager().Events())
 		}
+	}
+
+	// change to original context
+	k.WithContext(ctx)
+
+	// refund gas according to Ethereum gas accounting rules.
+	err = k.RefundGas(msg, msg.Gas()-res.GasUsed, cfg.Params.EvmDenom)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to refund gas leftover gas to sender %s", msg.From())
 	}
 
 	if len(logs) > 0 {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -239,8 +239,7 @@ func (k *Keeper) ApplyTransaction(tx *ethtypes.Transaction) (*types.MsgEthereumT
 	k.WithContext(ctx)
 
 	// refund gas according to Ethereum gas accounting rules.
-	err = k.RefundGas(msg, msg.Gas()-res.GasUsed, cfg.Params.EvmDenom)
-	if err != nil {
+	if err := k.RefundGas(msg, msg.Gas()-res.GasUsed, cfg.Params.EvmDenom); err != nil {
 		return nil, stacktrace.Propagate(err, "failed to refund gas leftover gas to sender %s", msg.From())
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Problem: When there are hooks and the transaction reverted, gas refund logic is reverted too.
Solution: Don't revert the gas refund logic

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
