### PR TITLE
Problem: too many files open (fix #768)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ For prerequisites and detailed build instructions please read the Evmos [Install
 make install
 ```
 
+for rpc endpoints bandwidth, setup open files limit before running the program:
+```
+ulimit -n 65535
+```
+
 Or check out the latest [release](https://github.com/tharsis/ethermint/releases).
 
 ## Quick Start

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# ulimit -n 65535 to prevent file open errors
 
 KEY="mykey"
 CHAINID="ethermint_9000-1"


### PR DESCRIPTION
Cause: golang http.Server is very fast and high performance, so if rpc usage is very hight, it affects p2p and consens
because they're in the same process. shares open files limit.

Solution: not use keep-alive, 0 timeout, sleep 5 milli-seconds for new connection
total open files is about 60 (previously over 1024 open files)

gives more priority to p2p and consensus
and make core more stable and p2p faster

ulimit -n (open file count for the process), varies with the system
mac: 256
linux: 1024