### PR TITLE
Problem: ForEachStorage sematic not compatible with go-ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (rpc) [tharsis#769](https://github.com/tharsis/ethermint/pull/769) Fix default Ethereum signer for JSON-RPC.
 * (rpc) [tharsis#781](https://github.com/tharsis/ethermint/pull/781) Fix get block invalid transactions filter.
 * (rpc) [tharsis#782](https://github.com/tharsis/ethermint/pull/782) Fix wrong block gas limit returned by JSON-RPC.
+* (evm) [tharsis#798](https://github.com/tharsis/ethermint/pull/798) Fix the semantic of `ForEachStorage` callback's return value
 
 ## [v0.8.0] - 2021-11-17
 

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -251,10 +251,9 @@ func initGenFiles(cfg Config, genAccounts []authtypes.GenesisAccount, genBalance
 }
 
 func WriteFile(name string, dir string, contents []byte) error {
-	writePath := filepath.Join(dir)
-	file := filepath.Join(writePath, name)
+	file := filepath.Join(dir, name)
 
-	err := tmos.EnsureDir(writePath, 0o755)
+	err := tmos.EnsureDir(dir, 0o755)
 	if err != nil {
 		return err
 	}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -295,7 +295,7 @@ func (k Keeper) GetAccountStorage(ctx sdk.Context, address common.Address) (type
 
 	err := k.ForEachStorage(address, func(key, value common.Hash) bool {
 		storage = append(storage, types.NewState(key, value))
-		return false
+		return true
 	})
 	if err != nil {
 		return types.Storage{}, err
@@ -317,7 +317,7 @@ func (k Keeper) DeleteState(addr common.Address, key common.Hash) {
 func (k Keeper) DeleteAccountStorage(addr common.Address) {
 	_ = k.ForEachStorage(addr, func(key, _ common.Hash) bool {
 		k.DeleteState(addr, key)
-		return false
+		return true
 	})
 }
 

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -795,6 +795,7 @@ func (k *Keeper) AddPreimage(_ common.Hash, _ []byte) {}
 
 // ForEachStorage uses the store iterator to iterate over all the state keys and perform a callback
 // function on each of them.
+// The callback should return `true` to continue, return `false` to break early.
 func (k *Keeper) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) error {
 	if k.HasStateError() {
 		return k.stateErr
@@ -814,7 +815,7 @@ func (k *Keeper) ForEachStorage(addr common.Address, cb func(key, value common.H
 		value := common.BytesToHash(iterator.Value())
 
 		// check if iteration stops
-		if cb(key, value) {
+		if !cb(key, value) {
 			return nil
 		}
 	}

--- a/x/evm/keeper/statedb_test.go
+++ b/x/evm/keeper/statedb_test.go
@@ -747,7 +747,7 @@ func (suite *KeeperTestSuite) TestForEachStorage() {
 			},
 			func(key, value common.Hash) bool {
 				storage = append(storage, types.NewState(key, value))
-				return false
+				return true
 			},
 			[]common.Hash{
 				common.BytesToHash([]byte("value0")),
@@ -766,9 +766,9 @@ func (suite *KeeperTestSuite) TestForEachStorage() {
 			func(key, value common.Hash) bool {
 				if value == common.BytesToHash([]byte("filtervalue")) {
 					storage = append(storage, types.NewState(key, value))
-					return true
+					return false
 				}
-				return false
+				return true
 			},
 			[]common.Hash{
 				common.BytesToHash([]byte("filtervalue")),


### PR DESCRIPTION
Solution:
- reversed the semantic of return value of the callback function.

ref: https://github.com/ethereum/go-ethereum/blob/master/core/state/statedb.go#L637

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
