### PR TITLE
x/evm/keeper: use the fastest slice making idiom for Keeper.EthereumTx.Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * (evm) [tharsis#826](https://github.com/tharsis/ethermint/issues/826) Improve allocation of bytes of `tx.To` address.
+* (evm) [tharsis#827](https://github.com/tharsis/ethermint/issues/827) Speed up creation of event logs by using the slice insertion idiom with indices.
 
 ### Bug Fixes
 

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -52,13 +52,13 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*t
 		attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyEthereumTxFailed, response.VmError))
 	}
 
-	txLogAttrs := make([]sdk.Attribute, 0)
-	for _, log := range response.Logs {
+	txLogAttrs := make([]sdk.Attribute, len(response.Logs))
+	for i, log := range response.Logs {
 		value, err := json.Marshal(log)
 		if err != nil {
 			return nil, sdkerrors.Wrap(err, "failed to encode log")
 		}
-		txLogAttrs = append(txLogAttrs, sdk.NewAttribute(types.AttributeKeyTxLog, string(value)))
+		txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
 	}
 
 	// emit events


### PR DESCRIPTION
Uses the fastest slice making idiom of creating the well known
size of a slice using

    make([]sdk.Attribute, len(response.Logs))
    for i, log := range response.Logs {
        txLogAttrs[i] = ...
    }

instead of

    make([]sdk.Attribute, 0)
    for _, log := range response.Logs {
        txLogAttrs = append(txLogAttrs, ...)
    }

which had a few problems:
1. Using 0 for size then appending is quite slow yet we know the exact size
2. Using append instead of indexing is slower

If we examine the advisory at https://bencher.orijtech.com/perfclinic/sliceupdate/
and the verdict at https://bencher.orijtech.com/perfclinic/sliceupdate/#verdict
this new scheme shows a massive improvement in that call site.

Fixes #825