### PR TITLE
x/evm/types: use ethtypes.Transaction.To for cheaper retrieval

### DIFF
--- a/x/evm/types/access_list_tx.go
+++ b/x/evm/types/access_list_tx.go
@@ -18,8 +18,8 @@ func newAccessListTx(tx *ethtypes.Transaction) (*AccessListTx, error) {
 	}
 
 	v, r, s := tx.RawSignatureValues()
-	if tx.To() != nil {
-		txData.To = tx.To().Hex()
+	if to := tx.To(); to != nil {
+		txData.To = to.Hex()
 	}
 
 	if tx.Value() != nil {

--- a/x/evm/types/dynamic_fee_tx.go
+++ b/x/evm/types/dynamic_fee_tx.go
@@ -20,8 +20,8 @@ func newDynamicFeeTx(tx *ethtypes.Transaction) (*DynamicFeeTx, error) {
 	}
 
 	v, r, s := tx.RawSignatureValues()
-	if tx.To() != nil {
-		txData.To = tx.To().Hex()
+	if to := tx.To(); to != nil {
+		txData.To = to.Hex()
 	}
 
 	if tx.Value() != nil {

--- a/x/evm/types/legacy_tx.go
+++ b/x/evm/types/legacy_tx.go
@@ -17,8 +17,8 @@ func newLegacyTx(tx *ethtypes.Transaction) (*LegacyTx, error) {
 	}
 
 	v, r, s := tx.RawSignatureValues()
-	if tx.To() != nil {
-		txData.To = tx.To().Hex()
+	if to := tx.To(); to != nil {
+		txData.To = to.Hex()
 	}
 
 	if tx.Value() != nil {


### PR DESCRIPTION
Following suit with PR #828, this change cuts down the expenses
from using .To doubly; yet using the Go in-condition variable idiom.

Updates #826