### PR TITLE
x/evm/types: properly split in 32 chunks trace.Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (rpc) [tharsis#831](https://github.com/tharsis/ethermint/pull/831) Fix BaseFee value when height is specified.
+* (evm) [tharsis#838](https://github.com/tharsis/ethermint/pull/838) Fix splitting of trace.Memory into 32 chunks.
 
 ## [v0.9.0] - 2021-12-01
 

--- a/x/evm/types/tracer.go
+++ b/x/evm/types/tracer.go
@@ -101,8 +101,13 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 
 		if trace.Memory != nil {
 			memory := make([]string, 0, (len(trace.Memory)+31)/32)
-			for i := 0; i+32 <= len(trace.Memory); i += 32 {
-				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:i+32]))
+			for i, n := 0, len(trace.Memory); i < n; {
+				end := i + 32
+				if end >= n {
+					end = n
+				}
+				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:end]))
+				i = end
 			}
 			formatted[index].Memory = &memory
 		}


### PR DESCRIPTION
This change fixes an insidious bug that unfortunately
tried to split values in multiples of 32, but unfortunately
due to the loop conditions, if the length of trace.Memory
was less than 32, nothing would be added; if the value wasn't
a multiple of 32, the ends wouldn't be added in.

Fixes #837