### PR TITLE
fix: contract address in contract creation receipt is wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (feemarket) [tharsis#822](https://github.com/tharsis/ethermint/pull/822) Update EIP1559 base fee in `BeginBlock`.
 - (evm) [tharsis#817](https://github.com/tharsis/ethermint/pull/817) Use `effectiveGasPrice` in ante handler, add `effectiveGasPrice` to tx receipt.
 - (evm) [tharsis#808](https://github.com/tharsis/ethermint/issues/808) increase nonce in ante handler for contract creation transaction.
+- (evm) [tharsis#851](https://github.com/tharsis/ethermint/pull/851) fix contract address used in EVM, this issue is caused by [tharsis#808](https://github.com/tharsis/ethermint/issues/808).
 - (evm) [tharsis#N/A]() reject invalid `MsgEthereumTx` wrapping tx
 - (evm) [tharsis#N/A]() Fix SelfDestruct opcode by deleting account code and state
 

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -665,12 +665,15 @@ func (suite *EvmTestSuite) TestContractDeploymentRevert() {
 			)
 			suite.SignTx(tx)
 
+			// simulate nonce increment in ante handler
+			k.SetNonce(suite.from, nonce+1)
+
 			rsp, err := k.EthereumTx(sdk.WrapSDKContext(suite.ctx), tx)
 			suite.Require().NoError(err)
 			suite.Require().True(rsp.Failed())
 
-			// nonce don't increase, it's increased in ante handler.
-			suite.Require().Equal(nonce, k.GetNonce(suite.from))
+			// nonce don't change
+			suite.Require().Equal(nonce+1, k.GetNonce(suite.from))
 		})
 	}
 }

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -208,10 +208,13 @@ func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, owner commo
 	ctorArgs, err := types.ERC20Contract.ABI.Pack("", owner, supply)
 	require.NoError(t, err)
 
+	nonce := suite.app.EvmKeeper.GetNonce(suite.address)
+
 	data := append(types.ERC20Contract.Bin, ctorArgs...)
 	args, err := json.Marshal(&types.TransactionArgs{
-		From: &suite.address,
-		Data: (*hexutil.Bytes)(&data),
+		From:  &suite.address,
+		Data:  (*hexutil.Bytes)(&data),
+		Nonce: (*hexutil.Uint64)(&nonce),
 	})
 	require.NoError(t, err)
 
@@ -220,8 +223,6 @@ func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, owner commo
 		GasCap: uint64(config.DefaultGasCap),
 	})
 	require.NoError(t, err)
-
-	nonce := suite.app.EvmKeeper.GetNonce(suite.address)
 
 	var erc20DeployTx *types.MsgEthereumTx
 	if suite.dynamicTxFee {

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -511,3 +511,9 @@ func (suite *KeeperTestSuite) TestEVMConfig() {
 	suite.Require().Equal(suite.address, cfg.CoinBase)
 	suite.Require().Equal(types.DefaultParams().ChainConfig.EthereumConfig(big.NewInt(9000)), cfg.ChainConfig)
 }
+
+func (suite *KeeperTestSuite) TestContractDeployment() {
+	suite.SetupTest()
+	contractAddress := suite.DeployTestContract(suite.T(), suite.address, big.NewInt(10000000000000))
+	suite.Require().Greater(suite.app.EvmKeeper.GetCodeSize(contractAddress), 0)
+}

--- a/x/evm/types/tx_args.go
+++ b/x/evm/types/tx_args.go
@@ -215,7 +215,13 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (e
 	if args.AccessList != nil {
 		accessList = *args.AccessList
 	}
-	msg := ethtypes.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, true)
+
+	nonce := uint64(0)
+	if args.Nonce != nil {
+		nonce = uint64(*args.Nonce)
+	}
+
+	msg := ethtypes.NewMessage(addr, args.To, nonce, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, true)
 	return msg, nil
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #850

## Description

- reset sender.nonce before evm.create
- add unit tests and rpc tests

How the nonce is changed:

```
Ante handler:
  check(tx.nonce == sender.nonce)
  sender.nonce += 1
ApplyMessage:
  if contract_creation {
    sender.nonce = tx.nonce
    err := evm.create(...)
    sender.nonce = tx.nonce + 1
  } else {
    evm.call(...)
  }
```

Two contraints for the design:
- sender's nonce should be increased even if `ApplyMessage` fails.
- `sender.nonce` should be equal to `tx.nonce` when calling `evm.create`, so the contract address will be correct.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
