### PR TITLE
ci: separate out rpc and integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,4 @@ jobs:
             .sum
       - run: |
           make build
-        if: "env.GIT_DIFF != ''"
+        if: env.GIT_DIFF

--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -35,4 +35,4 @@ jobs:
         run: |
           sudo make contract-tools
           sudo make test-contract
-        if: "env.GIT_DIFF != ''"
+        if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       - name: test-importer
         run: |
           make test-import
-        if: "env.GIT_DIFF != ''"
+        if: env.GIT_DIFF
 
   test-solidity:
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
       - name: test-solidity
         run: |
           ./scripts/run-solidity-tests.sh --batch=${{ matrix.batch }}
-        if: "env.GIT_DIFF != ''"
+        if: env.GIT_DIFF
 
   liveness-test:
     runs-on: ubuntu-latest
@@ -149,4 +149,24 @@ jobs:
       - name: Test rpc endpoint
         run: |
           make test-rpc
+        if: env.GIT_DIFF
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v2.4.0
+      - uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.sol
+            **/**.go
+            go.mod
+            go.sum
+      - name: Test e2e
+        run: |
+          make test-integration
         if: env.GIT_DIFF

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,9 @@ test-import:
 test-rpc:
 	./scripts/integration-test-all.sh -t "rpc" -q 1 -z 1 -s 2 -m "rpc" -r "true"
 
+test-integration:
+	./scripts/integration-test-all.sh -t "integration" -q 1 -z 1 -s 2 -m "integration" -r "true"
+
 test-rpc-pending:
 	./scripts/integration-test-all.sh -t "pending" -q 1 -z 1 -s 2 -m "pending" -r "true"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -127,7 +127,7 @@ if [[ -z $TEST || $TEST == "rpc" ]]; then
         MODE=$MODE HOST=$HOST_RPC go test ./tests/e2e/... -timeout=300s -v -short
         MODE=$MODE HOST=$HOST_RPC go test ./tests/rpc/... -timeout=300s -v -short
 
-        RPC_FAIL=$?
+        TEST_FAIL=$?
     done
     
 fi
@@ -150,8 +150,8 @@ for i in "${arr[@]}"; do
     stop_func "$i"
 done
 
-if [[ (-z $TEST || $TEST == "rpc") && $RPC_FAIL -ne 0 ]]; then
-    exit $RPC_FAIL
+if [[ (-z $TEST || $TEST == "rpc") && $TEST_FAIL -ne 0 ]]; then
+    exit $TEST_FAIL
 else
     exit 0
 fi

--- a/tests/e2e/integration_test.go
+++ b/tests/e2e/integration_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	evmtypes "github.com/tharsis/ethermint/x/evm/types"
 	"math/big"
 	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
 
 	// . "github.com/onsi/ginkgo"
 	// . "github.com/onsi/gomega"
@@ -392,6 +393,7 @@ func (s *IntegrationTestSuite) TestGetLogs() {
 		common.HexToHash("0x000000000000000000000000" + fmt.Sprintf("%x", common.BytesToAddress(s.network.Validators[0].Address))),
 		common.HexToHash("0x000000000000000000000000378c50d9264c63f3f92b806d4ee56e9d86ffb3ec"),
 	}
+
 	s.Require().Equal(expectedTopics, logs[0].Topics)
 }
 


### PR DESCRIPTION
## Description

We will be retiring `rpc` tests pretty soon so this job separates out the e2e tests and `rpc` tests in different workflows. When and if we are ready to retire the `rpc` tests we can go ahead and remove the `rpc` workflow. 

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [x] Reviewers assigned
- [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
