### PR TITLE
eth_feeHistory - fix reward calculation from MsgEthereumTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+
+* (rpc) [tharsis#990](https://github.com/tharsis/ethermint/pull/990) Calculate reward values from all `MsgEthereumTx` from a block in `eth_feeHistory`.
+
+## [v0.11.0] - 2022-03-06
+
 ### State Machine Breaking
 
 * (ante) [tharsis#964](https://github.com/tharsis/ethermint/pull/964) add NewInfiniteGasMeterWithLimit for storing the user provided gas limit. Fixes block's consumed gas calculation in the block creation phase.

--- a/rpc/ethereum/backend/feebackend.go
+++ b/rpc/ethereum/backend/feebackend.go
@@ -61,14 +61,15 @@ func (e *EVMBackend) processBlock(
 	rewardCount := len(rewardPercentiles)
 	targetOneFeeHistory.Reward = make([]*big.Int, rewardCount)
 	for i := 0; i < rewardCount; i++ {
-		targetOneFeeHistory.Reward[i] = big.NewInt(2000)
+		targetOneFeeHistory.Reward[i] = big.NewInt(0)
 	}
 
 	// check tendermintTxs
 	tendermintTxs := tendermintBlock.Block.Txs
 	tendermintTxResults := tendermintBlockResult.TxsResults
 	tendermintTxCount := len(tendermintTxs)
-	sorter := make(sortGasAndReward, tendermintTxCount)
+
+	var sorter sortGasAndReward
 
 	for i := 0; i < tendermintTxCount; i++ {
 		eachTendermintTx := tendermintTxs[i]
@@ -90,29 +91,28 @@ func (e *EVMBackend) processBlock(
 			if reward == nil {
 				reward = big.NewInt(0)
 			}
-			sorter[i] = txGasAndReward{gasUsed: txGasUsed, reward: reward}
-			break
+			sorter = append(sorter, txGasAndReward{gasUsed: txGasUsed, reward: reward})
 		}
 	}
+
+	// return an all zero row if there are no transactions to gather data from
+	ethTxCount := len(sorter)
+	if ethTxCount == 0 {
+		return nil
+	}
+
 	sort.Sort(sorter)
 
 	var txIndex int
-	sumGasUsed := uint64(0)
-	if len(sorter) > 0 {
-		sumGasUsed = sorter[0].gasUsed
-	}
+	sumGasUsed := sorter[0].gasUsed
+
 	for i, p := range rewardPercentiles {
 		thresholdGasUsed := uint64(blockGasUsed * p / 100)
-		for sumGasUsed < thresholdGasUsed && txIndex < tendermintTxCount-1 {
+		for sumGasUsed < thresholdGasUsed && txIndex < ethTxCount-1 {
 			txIndex++
 			sumGasUsed += sorter[txIndex].gasUsed
 		}
-
-		chosenReward := big.NewInt(0)
-		if 0 <= txIndex && txIndex < len(sorter) {
-			chosenReward = sorter[txIndex].reward
-		}
-		targetOneFeeHistory.Reward[i] = chosenReward
+		targetOneFeeHistory.Reward[i] = sorter[txIndex].reward
 	}
 
 	return nil


### PR DESCRIPTION
Problem:
- rewards calculation based on percentiles took into consideration the tendermint tx count instead of `MsgEthereumTx` count.
- `sorter := make(sortGasAndReward, tendermintTxCount)` creates an array of `{0 <nil>}` values.
The `nil` value from the `reward` attribute was never rewritten for tendermint Tx without any `MsgEthereumTx`

Fixes:
- return early if there are 0 `MsgEthereumTx`, as in:
https://github.com/ethereum/go-ethereum/blob/57cec892536270fc6dafae01ded2c528ffa370e9/eth/gasprice/feehistory.go#L106-L113
- use the `MsgEthereumTx` count to calculate rewards

Fixes https://github.com/tharsis/ethermint/issues/974

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
