### PR TITLE
fix: Update the JSON-RPC to correct the return information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (rpc) [tharsis#990](https://github.com/tharsis/ethermint/pull/990) Calculate reward values from all `MsgEthereumTx` from a block in `eth_feeHistory`.
 * (ante) [tharsis#991](https://github.com/tharsis/ethermint/pull/991) Set an upper bound to gasWanted to prevent DoS attack.
+* (rpc) [tharsis#1006](https://github.com/tharsis/ethermint/pull/1006) Use `string` as the parameters type to correct ambiguous results.
 
 ## [v0.11.0] - 2022-03-06
 

--- a/rpc/ethereum/namespaces/web3/api.go
+++ b/rpc/ethereum/namespaces/web3/api.go
@@ -21,6 +21,6 @@ func (a *PublicAPI) ClientVersion() string {
 }
 
 // Sha3 returns the keccak-256 hash of the passed-in input.
-func (a *PublicAPI) Sha3(input hexutil.Bytes) hexutil.Bytes {
-	return crypto.Keccak256(input)
+func (a *PublicAPI) Sha3(input string) hexutil.Bytes {
+	return crypto.Keccak256(hexutil.Bytes(input))
 }

--- a/tests/e2e/integration_test.go
+++ b/tests/e2e/integration_test.go
@@ -46,6 +46,7 @@ type IntegrationTestSuite struct {
 
 	gethClient *gethclient.Client
 	ethSigner  ethtypes.Signer
+	rpcClient  *rpc.Client
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -74,6 +75,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	rpcClient, err := rpc.DialContext(s.ctx, address)
 	s.Require().NoError(err)
+	s.rpcClient = rpcClient
 	s.gethClient = gethclient.New(rpcClient)
 	s.Require().NotNil(s.gethClient)
 	chainId, err := ethermint.ParseChainID(s.cfg.ChainID)
@@ -684,4 +686,27 @@ func (s *IntegrationTestSuite) waitForTransaction() {
 
 func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
+}
+
+func (s *IntegrationTestSuite) TestWeb3Sha3() {
+	expectedRes1 := "0x23e7488ec9097f0126b0338926bfaeb5264b01cb162a0fd4a6d76e1081c2b24a"
+
+	var result1 string
+	err1 := s.rpcClient.Call(&result1, "web3_sha3", "0xabcd1234567890")
+	s.Require().NoError(err1)
+	s.Require().Equal(expectedRes1, result1)
+
+	expectedRes2 := "0x39bef1777deb3dfb14f64b9f81ced092c501fee72f90e93d03bb95ee89df9837"
+
+	var result2 string
+	err2 := s.rpcClient.Call(&result2, "web3_sha3", "0x")
+	s.Require().NoError(err2)
+	s.Require().Equal(expectedRes2, result2)
+
+	expectedRes3 := "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+
+	var result3 string
+	err3 := s.rpcClient.Call(&result3, "web3_sha3", "")
+	s.Require().NoError(err3)
+	s.Require().Equal(expectedRes3, result3)
 }

--- a/tests/e2e/integration_test.go
+++ b/tests/e2e/integration_test.go
@@ -689,24 +689,35 @@ func TestIntegrationTestSuite(t *testing.T) {
 }
 
 func (s *IntegrationTestSuite) TestWeb3Sha3() {
-	expectedRes1 := "0x23e7488ec9097f0126b0338926bfaeb5264b01cb162a0fd4a6d76e1081c2b24a"
+	testCases := []struct {
+		name     string
+		arg      string
+		expected string
+	}{
+		{
+			"normal input",
+			"0xabcd1234567890",
+			"0x23e7488ec9097f0126b0338926bfaeb5264b01cb162a0fd4a6d76e1081c2b24a",
+		},
+		{
+			"0x case",
+			"0x",
+			"0x39bef1777deb3dfb14f64b9f81ced092c501fee72f90e93d03bb95ee89df9837",
+		},
+		{
+			"empty string case",
+			"",
+			"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+		},
+	}
 
-	var result1 string
-	err1 := s.rpcClient.Call(&result1, "web3_sha3", "0xabcd1234567890")
-	s.Require().NoError(err1)
-	s.Require().Equal(expectedRes1, result1)
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			var result string
 
-	expectedRes2 := "0x39bef1777deb3dfb14f64b9f81ced092c501fee72f90e93d03bb95ee89df9837"
-
-	var result2 string
-	err2 := s.rpcClient.Call(&result2, "web3_sha3", "0x")
-	s.Require().NoError(err2)
-	s.Require().Equal(expectedRes2, result2)
-
-	expectedRes3 := "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
-
-	var result3 string
-	err3 := s.rpcClient.Call(&result3, "web3_sha3", "")
-	s.Require().NoError(err3)
-	s.Require().Equal(expectedRes3, result3)
+			err := s.rpcClient.Call(&result, "web3_sha3", tc.arg)
+			s.Require().NoError(err)
+			s.Require().Equal(tc.expected, result)
+		})
+	}
 }

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -135,33 +135,6 @@ func callWithError(method string, params interface{}) (*Response, error) {
 	return rpcRes, nil
 }
 
-func TestWeb3_Sha3(t *testing.T) {
-	expectedRes1 := "0x23e7488ec9097f0126b0338926bfaeb5264b01cb162a0fd4a6d76e1081c2b24a"
-	rpcRes1 := call(t, "web3_sha3", []string{"0xabcd1234567890"})
-
-	res1 := hexutil.Bytes{}
-	err1 := res1.UnmarshalJSON(rpcRes1.Result)
-	require.NoError(t, err1)
-	require.Equal(t, expectedRes1, res1.String(), "expected: %s got: %s\n", expectedRes1, rpcRes1.Result)
-
-	expectedRes2 := "0x39bef1777deb3dfb14f64b9f81ced092c501fee72f90e93d03bb95ee89df9837"
-	rpcRes2 := call(t, "web3_sha3", []string{"0x"})
-
-	res2 := hexutil.Bytes{}
-	err2 := res2.UnmarshalJSON(rpcRes2.Result)
-	require.NoError(t, err2)
-	require.Equal(t, expectedRes2, res2.String(), "expected: %s got: %s\n", expectedRes2, rpcRes2.Result)
-
-	expectedRes3 := "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
-	rpcRes3 := call(t, "web3_sha3", []string{""})
-
-	res3 := hexutil.Bytes{}
-	err3 := res3.UnmarshalJSON(rpcRes3.Result)
-	require.NoError(t, err3)
-	require.Equal(t, expectedRes3, res3.String(), "expected: %s got: %s\n", expectedRes3, rpcRes3.Result)
-
-}
-
 func TestEth_protocolVersion(t *testing.T) {
 	expectedRes := hexutil.Uint(ethermint.ProtocolVersion)
 

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -135,6 +135,33 @@ func callWithError(method string, params interface{}) (*Response, error) {
 	return rpcRes, nil
 }
 
+func TestWeb3_Sha3(t *testing.T) {
+	expectedRes1 := "0x23e7488ec9097f0126b0338926bfaeb5264b01cb162a0fd4a6d76e1081c2b24a"
+	rpcRes1 := call(t, "web3_sha3", []string{"0xabcd1234567890"})
+
+	res1 := hexutil.Bytes{}
+	err1 := res1.UnmarshalJSON(rpcRes1.Result)
+	require.NoError(t, err1)
+	require.Equal(t, expectedRes1, res1.String(), "expected: %s got: %s\n", expectedRes1, rpcRes1.Result)
+
+	expectedRes2 := "0x39bef1777deb3dfb14f64b9f81ced092c501fee72f90e93d03bb95ee89df9837"
+	rpcRes2 := call(t, "web3_sha3", []string{"0x"})
+
+	res2 := hexutil.Bytes{}
+	err2 := res2.UnmarshalJSON(rpcRes2.Result)
+	require.NoError(t, err2)
+	require.Equal(t, expectedRes2, res2.String(), "expected: %s got: %s\n", expectedRes2, rpcRes2.Result)
+
+	expectedRes3 := "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+	rpcRes3 := call(t, "web3_sha3", []string{""})
+
+	res3 := hexutil.Bytes{}
+	err3 := res3.UnmarshalJSON(rpcRes3.Result)
+	require.NoError(t, err3)
+	require.Equal(t, expectedRes3, res3.String(), "expected: %s got: %s\n", expectedRes3, rpcRes3.Result)
+
+}
+
 func TestEth_protocolVersion(t *testing.T) {
 	expectedRes := hexutil.Uint(ethermint.ProtocolVersion)
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Fixes: #632 

Solution:

Before the fix, the "web3_sha3" JSON_RPC endpoint will overwrite the "0x" as "" by using "hexutil.Bytes" as the input parameters, then return same result. After the fix, using "string" as the input parameters will avoid the overwrite and return correct response.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
