### PR TITLE
Fix RPC with batch Ethereum txs 

### DIFF
--- a/rpc/ethereum/backend/backend.go
+++ b/rpc/ethereum/backend/backend.go
@@ -362,6 +362,7 @@ func (e *EVMBackend) EthBlockFromTendermint(
 	}
 
 	txResults := resBlockResult.TxsResults
+	txIndex := uint64(0)
 
 	for i, txBz := range block.Txs {
 		tx, err := e.clientCtx.TxConfig.TxDecoder()(txBz)
@@ -394,14 +395,16 @@ func (e *EVMBackend) EthBlockFromTendermint(
 				tx,
 				common.BytesToHash(block.Hash()),
 				uint64(block.Height),
-				uint64(i),
+				txIndex,
 				baseFee,
 			)
 			if err != nil {
 				e.logger.Debug("NewTransactionFromData for receipt failed", "hash", tx.Hash().Hex(), "error", err.Error())
 				continue
 			}
+
 			ethRPCTxs = append(ethRPCTxs, rpcTx)
+			txIndex++
 		}
 	}
 

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -363,7 +363,7 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-	ctx = ctx.WithBlockHeight(req.BlockNumber)
+	ctx = ctx.WithBlockHeight(req.BlockNumber - 1)
 	ctx = ctx.WithBlockTime(req.BlockTime)
 	ctx = ctx.WithHeaderHash(common.Hex2Bytes(req.BlockHash))
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently when a Cosmos txs has several ETH txs messages, `eth_getBlockByNumber` returns all txs in that batch with the same index. 

Also, fixed an issue on traceTransaction where we need to use the previous block number on the context.
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
