### PR TITLE
Ante: Respect minimum-gas-price when london fork is enabled and fee market is disabled

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -185,6 +185,16 @@ func (suite AnteTestSuite) TestAnteHandler() {
 			}, false, true, true,
 		},
 		{
+			"fail - CheckTx (gas price under minimum)",
+			func() sdk.Tx {
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 8, &to, big.NewInt(10), 100000, MinimumGasPrice.Sub(sdk.NewInt(1)).BigInt(), nil, nil, nil, nil)
+				signedTx.From = addr.Hex()
+
+				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)
+				return txBuilder.GetTx()
+			}, true, false, false,
+		},
+		{
 			"fail - CheckTx (cosmos tx is not valid)",
 			func() sdk.Tx {
 				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 8, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -1,11 +1,11 @@
 package ante_test
 
 import (
-	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"math/big"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	ethparams "github.com/ethereum/go-ethereum/params"
@@ -43,7 +43,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					1,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -64,7 +64,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					2,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -85,7 +85,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					3,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -107,7 +107,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					&to,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -129,7 +129,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					&to,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -151,7 +151,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					&to,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -172,7 +172,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					&to,
 					big.NewInt(10),
 					100000,
-					big.NewInt(150),
+					MinimumGasPrice.Mul(sdk.NewInt(15)).BigInt(),
 					big.NewInt(200),
 					nil,
 					nil,
@@ -187,7 +187,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 		{
 			"fail - CheckTx (cosmos tx is not valid)",
 			func() sdk.Tx {
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 8, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 8, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)
@@ -199,7 +199,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 		{
 			"fail - CheckTx (memo too long)",
 			func() sdk.Tx {
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 5, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 5, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)
@@ -210,7 +210,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 		{
 			"fail - CheckTx (ExtensionOptionsEthereumTx not set)",
 			func() sdk.Tx {
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 5, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 5, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false, true)
@@ -224,7 +224,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 			func() sdk.Tx {
 				nonce, err := suite.app.AccountKeeper.GetSequence(suite.ctx, acc.GetAddress())
 				suite.Require().NoError(err)
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				tx := suite.CreateTestTx(signedTx, privKey, 1, true)
@@ -236,7 +236,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 			func() sdk.Tx {
 				nonce, err := suite.app.AccountKeeper.GetSequence(suite.ctx, acc.GetAddress())
 				suite.Require().NoError(err)
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)
@@ -249,7 +249,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 			func() sdk.Tx {
 				nonce, err := suite.app.AccountKeeper.GetSequence(suite.ctx, acc.GetAddress())
 				suite.Require().NoError(err)
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)
@@ -262,7 +262,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 			func() sdk.Tx {
 				nonce, err := suite.app.AccountKeeper.GetSequence(suite.ctx, acc.GetAddress())
 				suite.Require().NoError(err)
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)
@@ -282,7 +282,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 			func() sdk.Tx {
 				nonce, err := suite.app.AccountKeeper.GetSequence(suite.ctx, acc.GetAddress())
 				suite.Require().NoError(err)
-				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, big.NewInt(1), nil, nil, nil, nil)
+				signedTx := evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), nonce, &to, big.NewInt(10), 100000, MinimumGasPrice.BigInt(), nil, nil, nil, nil)
 				signedTx.From = addr.Hex()
 
 				txBuilder := suite.CreateTestTxBuilder(signedTx, privKey, 1, false)

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -5,8 +5,6 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 

--- a/app/ante/eth.go
+++ b/app/ante/eth.go
@@ -510,7 +510,7 @@ func (mfd EthMempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 		params := mfd.evmKeeper.GetParams(ctx)
 		ethCfg := params.ChainConfig.EthereumConfig(mfd.evmKeeper.ChainID())
 		baseFee := mfd.evmKeeper.GetBaseFee(ctx, ethCfg)
-		if baseFee == nil {
+		if baseFee == nil || baseFee.BitLen() == 0 {
 			for _, msg := range tx.GetMsgs() {
 				ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
 				if !ok {

--- a/app/ante/utils_test.go
+++ b/app/ante/utils_test.go
@@ -41,6 +41,8 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
+var MinimumGasPrice = sdk.NewInt(10)
+
 type AnteTestSuite struct {
 	suite.Suite
 
@@ -94,7 +96,7 @@ func (suite *AnteTestSuite) SetupTest() {
 	})
 
 	suite.ctx = suite.app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 2, ChainID: "ethermint_9000-1", Time: time.Now().UTC()})
-	suite.ctx = suite.ctx.WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoin(evmtypes.DefaultEVMDenom, sdk.NewInt(10))))
+	suite.ctx = suite.ctx.WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoin(evmtypes.DefaultEVMDenom, MinimumGasPrice)))
 	suite.ctx = suite.ctx.WithBlockGasMeter(sdk.NewGasMeter(1000000000000000000))
 	suite.app.EvmKeeper.WithChainID(suite.ctx)
 

--- a/app/ante/utils_test.go
+++ b/app/ante/utils_test.go
@@ -66,6 +66,17 @@ func (suite *AnteTestSuite) SetupTest() {
 			feemarketGenesis := feemarkettypes.DefaultGenesisState()
 			feemarketGenesis.Params.EnableHeight = 1
 			feemarketGenesis.Params.NoBaseFee = false
+
+			// Verify feeMarket genesis
+			err := feemarketGenesis.Validate()
+			suite.Require().NoError(err)
+			genesis[feemarkettypes.ModuleName] = app.AppCodec().MustMarshalJSON(feemarketGenesis)
+		} else {
+			// setup feemarketGenesis params
+			feemarketGenesis := feemarkettypes.DefaultGenesisState()
+			feemarketGenesis.Params.EnableHeight = 0
+			feemarketGenesis.Params.NoBaseFee = true // disable fee market in ante chain
+
 			// Verify feeMarket genesis
 			err := feemarketGenesis.Validate()
 			suite.Require().NoError(err)
@@ -83,7 +94,7 @@ func (suite *AnteTestSuite) SetupTest() {
 	})
 
 	suite.ctx = suite.app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 2, ChainID: "ethermint_9000-1", Time: time.Now().UTC()})
-	suite.ctx = suite.ctx.WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoin(evmtypes.DefaultEVMDenom, sdk.OneInt())))
+	suite.ctx = suite.ctx.WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoin(evmtypes.DefaultEVMDenom, sdk.NewInt(10))))
 	suite.ctx = suite.ctx.WithBlockGasMeter(sdk.NewGasMeter(1000000000000000000))
 	suite.app.EvmKeeper.WithChainID(suite.ctx)
 

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -201,7 +201,7 @@ func (e *PublicAPI) GasPrice() (*hexutil.Big, error) {
 		result *big.Int
 		err    error
 	)
-	if head := e.backend.CurrentHeader(); head.BaseFee != nil {
+	if head := e.backend.CurrentHeader(); head.BaseFee != nil && head.BaseFee.BitLen() > 0 {
 		result, err = e.backend.SuggestGasTipCap(head.BaseFee)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This updates the EthMempoolDecorator to repsect the minimum gas price if london is enabled and NoBaseFee is set to true in the feemarket module.  In addition, the eth_gasPrice endpoint is modified to return the set minimum gas price in this case as well.

I believe this is the intended behavior based on the EthMempoolDecorator comments, but please lmk if this is not the case.

The ante tests where modified to ensure we are always using a gas price above the minimum, as well as to fix the test setup to set NoBaseFee to true when the feemarket is disabled.