### PR TITLE
impr(evm): add tx_type, gas and counter telemetry for ethereum txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (cli) [tharsis#1086](https://github.com/tharsis/ethermint/pull/1086) Add rollback command.
 * (specs) [tharsis#1095](https://github.com/tharsis/ethermint/pull/1095) Add more evm specs concepts.
+* (evm) [tharsis#1101](https://github.com/tharsis/ethermint/pull/1101) Add tx_type, gas and counter telemetry for ethereum txs.
 
 ### Bug Fixes
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tharsis/ethermint
 go 1.17
 
 require (
+	github.com/armon/go-metrics v0.3.10
 	github.com/btcsuite/btcd v0.22.1
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cosmos/cosmos-sdk v0.45.4
@@ -45,7 +46,6 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
-	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect


### PR DESCRIPTION
## Description

This PR adds telemetry for Ethereum txs. This functionality was originally removed with https://github.com/tharsis/ethermint/pull/545/files because of performance issues with `telemetry.ModuleMeasureSince`, which are not readded.