### PR TITLE
analytics(app): update telemetry to Ethermint modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (feemarket) [tharsis#1104](https://github.com/tharsis/ethermint/pull/1104) Enforce a minimum gas price for Cosmos and EVM transactions through the `MinGasPrice` parameter.
 - (rpc) [tharsis#1081](https://github.com/tharsis/ethermint/pull/1081) Deduplicate some json-rpc logic codes, cleanup several dead functions.
 - (ante) [tharsis#1062](https://github.com/tharsis/ethermint/pull/1062) Emit event of eth tx hash in ante handler to support query failed transactions.
+- (analytics) [tharsis#1106](https://github.com/tharsis/ethermint/pull/1106) Update telemetry to Ethermint modules.
 
 ### Improvements
 

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -48,18 +48,19 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*t
 	}
 
 	defer func() {
-		if tx.Value().IsInt64() {
-			telemetry.SetGauge(
-				float32(tx.Value().Int64()),
-				"tx", "msg", "ethereum_tx",
-			)
-		}
-
 		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, "ethereum_tx"},
+			[]string{"tx", "msg", "ethereum_tx", "total"},
 			1,
 			labels,
 		)
+
+		if response.GasUsed != 0 {
+			telemetry.IncrCounterWithLabels(
+				[]string{"tx", "msg", "ethereum_tx", "gas_used", "total"},
+				float32(response.GasUsed),
+				labels,
+			)
+		}
 	}()
 
 	attrs := []sdk.Attribute{

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -62,8 +62,8 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*t
 				labels,
 			)
 
-			// Observe which users define a gas limit >> gas used. Note, that gas
-			// limit is always > 0
+			// Observe which users define a gas limit >> gas used. Note, that
+			// gas_limit and gas_used are always > 0
 			gasLimit := sdk.NewDec(int64(tx.Gas()))
 			gasRatio, err := gasLimit.QuoInt64(int64(response.GasUsed)).Float64()
 			if err == nil {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -278,8 +278,7 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*t
 	}
 
 	// refund gas in order to match the Ethereum gas consumption instead of the default SDK one.
-	refund := msg.Gas() - res.GasUsed
-	if err = k.RefundGas(ctx, msg, refund, cfg.Params.EvmDenom); err != nil {
+	if err = k.RefundGas(ctx, msg, msg.Gas()-res.GasUsed, cfg.Params.EvmDenom); err != nil {
 		return nil, sdkerrors.Wrapf(err, "failed to refund gas leftover gas to sender %s", msg.From())
 	}
 
@@ -298,7 +297,6 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*t
 
 	// reset the gas meter for current cosmos transaction
 	k.ResetGasMeterAndConsumeGas(ctx, totalGasUsed)
-
 	return res, nil
 }
 

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -6,7 +6,6 @@ import (
 
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -299,13 +298,6 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*t
 
 	// reset the gas meter for current cosmos transaction
 	k.ResetGasMeterAndConsumeGas(ctx, totalGasUsed)
-
-	defer func() {
-		telemetry.IncrCounter(
-			float32(refund),
-			"tx", "msg", "ethereum", "tx_refund", "total",
-		)
-	}()
 
 	return res, nil
 }

--- a/x/feemarket/keeper/abci.go
+++ b/x/feemarket/keeper/abci.go
@@ -6,6 +6,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tharsis/ethermint/x/feemarket/types"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -19,6 +20,10 @@ func (k *Keeper) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 	}
 
 	k.SetBaseFee(ctx, baseFee)
+
+	defer func() {
+		telemetry.SetGauge(float32(baseFee.Int64()), "fee_market", "base_fee")
+	}()
 
 	// Store current base fee in event
 	ctx.EventManager().EmitEvents(sdk.Events{
@@ -41,6 +46,10 @@ func (k *Keeper) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) {
 	gasUsed := ctx.BlockGasMeter().GasConsumedToLimit()
 
 	k.SetBlockGasUsed(ctx, gasUsed)
+
+	defer func() {
+		telemetry.SetGauge(float32(gasUsed), "fee_market", "block_gas")
+	}()
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		"block_gas",

--- a/x/feemarket/keeper/abci.go
+++ b/x/feemarket/keeper/abci.go
@@ -22,7 +22,7 @@ func (k *Keeper) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 	k.SetBaseFee(ctx, baseFee)
 
 	defer func() {
-		telemetry.SetGauge(float32(baseFee.Int64()), "fee_market", "base_fee")
+		telemetry.SetGauge(float32(baseFee.Int64()), "feemarket", "base_fee")
 	}()
 
 	// Store current base fee in event
@@ -48,7 +48,7 @@ func (k *Keeper) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) {
 	k.SetBlockGasUsed(ctx, gasUsed)
 
 	defer func() {
-		telemetry.SetGauge(float32(gasUsed), "fee_market", "block_gas")
+		telemetry.SetGauge(float32(gasUsed), "feemarket", "block_gas")
 	}()
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(


### PR DESCRIPTION
## Description

This PR adds telemetry to Ethermint modules and is an advancement of the recent [telemetry implementation on Evmos](https://github.com/tharsis/evmos/pull/637).


## Metrics 

I implemented the following metrics to observe. They still need to be  added  to the respective specs that use Ethermint:

| Metric                                      | Description                                      | Unit  | Type  |
| :------------------------------------------ | :----------------------------------------------- | :---- | :---- |
| `feemarket_base_fee`                        | Amount of base fee per EIP-1559 block            | token | gauge |
| `feemarket_block_gas`                       | Amount of gas used in an EIP-1559 block           | token | gauge |
| `tx_msg_ethereum_tx_gas_limit_per_gas_used` | Ratio of gas limit to gas used for a etheruem tx | ratio | gauge |
